### PR TITLE
fix: lib scan no longer bails out on missing metadata

### DIFF
--- a/packages/client/web/app/game/media.tsx
+++ b/packages/client/web/app/game/media.tsx
@@ -9,7 +9,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
-import { Image } from "@/lib/utils";
+import { cn, Image } from "@/lib/utils";
 
 export function Media() {
   const { gameMetadata } = useGameDetail();
@@ -84,11 +84,19 @@ function ImageCarousel(props: { images: string[] }) {
       <CarouselContent className="h-max">
         {images.map((img, idx) => (
           <CarouselItem key={idx}>
-            <Image
-              src={img}
-              className="w-full aspect-video rounded-lg"
-              alt=""
-            />
+            <div
+              className={cn(
+                "relative h-full aspect-video rounded-lg overflow-hidden",
+                "flex justify-center items-center",
+              )}
+            >
+              <Image
+                src={img}
+                className="absolute inset-0 blur-3xl z-[-1]"
+                alt=""
+              />
+              <Image src={img} className="max-h-full mx-auto" alt="" />
+            </div>
           </CarouselItem>
         ))}
       </CarouselContent>

--- a/packages/client/web/components/update-metadata-dialog/index.tsx
+++ b/packages/client/web/components/update-metadata-dialog/index.tsx
@@ -8,26 +8,24 @@ type Props = ComponentProps<typeof DialogContent>;
 
 export function UpdateMetadataDialog(props: Props) {
   return (
-    <DialogOverlay>
-      <DialogContent {...props}>
-        <DialogHeader className="text-2xl font-black">
-          Update Metadata
-        </DialogHeader>
+    <DialogContent {...props}>
+      <DialogHeader className="text-2xl font-black">
+        Update Metadata
+      </DialogHeader>
 
-        <Tabs defaultValue="igdb">
-          <TabsList>
-            <TabsTrigger value="igdb">Search IGDB</TabsTrigger>
-            <TabsTrigger value="manual">Manual</TabsTrigger>
-          </TabsList>
+      <Tabs defaultValue="igdb">
+        <TabsList>
+          <TabsTrigger value="igdb">Search IGDB</TabsTrigger>
+          <TabsTrigger value="manual">Manual</TabsTrigger>
+        </TabsList>
 
-          <TabsContent value="igdb">
-            <IgdbTab />
-          </TabsContent>
-          <TabsContent value="manual">
-            <ManualTab />
-          </TabsContent>
-        </Tabs>
-      </DialogContent>
-    </DialogOverlay>
+        <TabsContent value="igdb">
+          <IgdbTab />
+        </TabsContent>
+        <TabsContent value="manual">
+          <ManualTab />
+        </TabsContent>
+      </Tabs>
+    </DialogContent>
   );
 }


### PR DESCRIPTION
The lib scan now continues even if specific metadata is
not found for a game. This is to prevent the scan from
stopping prematurely, when other metadata may still be
available.