### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.11...retrom-v0.0.12) - 2024-07-31
+
+### Added
+- web client ssl
+
+### Fixed
+- rendering issues
+- rate-limited igdb metadata fetching
+- publish
+
 ## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.10...retrom-v0.0.11) - 2024-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,11 +3711,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.11"
+version = "0.0.12"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "async-compression",
  "bb8",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "diesel",
  "prost",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "dotenvy",
  "retrom-codegen",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.11"
+version = "0.0.12"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,11 +44,11 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.8" }
-retrom-client = { path = "./packages/client", version = "0.0.10" }
-retrom-service = { path = "./packages/service", version = "0.0.8" }
-retrom-codegen = { path = "./packages/codegen", version = "0.0.8" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.8" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.9" }
+retrom-client = { path = "./packages/client", version = "0.0.11" }
+retrom-service = { path = "./packages/service", version = "0.0.9" }
+retrom-codegen = { path = "./packages/codegen", version = "0.0.9" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.10" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.10...retrom-client-v0.0.11) - 2024-07-31
+
+### Added
+- web client ssl
+
+### Fixed
+- rendering issues
+- rate-limited igdb metadata fetching
+
 ## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.9...retrom-client-v0.0.10) - 2024-07-27
 
 ### Other

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.10"
+version = "0.0.11"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -6,12 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.9...retrom-plugin-launcher-v0.0.10) - 2024-07-31
+## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.8...retrom-codegen-v0.0.9) - 2024-07-31
 
 ### Fixed
 - rate-limited igdb metadata fetching
-
-## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.8...retrom-plugin-launcher-v0.0.9) - 2024-07-27
-
-### Other
-- clean up

--- a/packages/codegen/Cargo.toml
+++ b/packages/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-codegen"
-version = "0.0.8"
+version = "0.0.9"
 description = "Code generation for Retrom"
 authors.workspace = true
 repository.workspace = true

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,12 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.9...retrom-plugin-launcher-v0.0.10) - 2024-07-31
+## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.8...retrom-service-v0.0.9) - 2024-07-31
 
 ### Fixed
 - rate-limited igdb metadata fetching
-
-## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.8...retrom-plugin-launcher-v0.0.9) - 2024-07-27
-
-### Other
-- clean up

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-service"
-version = "0.0.8"
+version = "0.0.9"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/plugins/retrom-plugin-installer/CHANGELOG.md
+++ b/plugins/retrom-plugin-installer/CHANGELOG.md
@@ -6,12 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.9...retrom-plugin-launcher-v0.0.10) - 2024-07-31
+## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-plugin-installer-v0.0.8...retrom-plugin-installer-v0.0.9) - 2024-07-31
 
 ### Fixed
 - rate-limited igdb metadata fetching
-
-## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.8...retrom-plugin-launcher-v0.0.9) - 2024-07-27
-
-### Other
-- clean up

--- a/plugins/retrom-plugin-installer/Cargo.toml
+++ b/plugins/retrom-plugin-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-plugin-installer"
-version = "0.0.8"
+version = "0.0.9"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/plugins/retrom-plugin-launcher/Cargo.toml
+++ b/plugins/retrom-plugin-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-plugin-launcher"
-version = "0.0.9"
+version = "0.0.10"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.10 -> 0.0.11
* `retrom-codegen`: 0.0.8 -> 0.0.9
* `retrom-plugin-installer`: 0.0.8 -> 0.0.9
* `retrom-plugin-launcher`: 0.0.9 -> 0.0.10
* `retrom-service`: 0.0.8 -> 0.0.9
* `retrom`: 0.0.11 -> 0.0.12

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.10...retrom-client-v0.0.11) - 2024-07-31

### Added
- web client ssl

### Fixed
- rendering issues
- rate-limited igdb metadata fetching
</blockquote>

## `retrom-codegen`
<blockquote>

## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.8...retrom-codegen-v0.0.9) - 2024-07-31

### Fixed
- rate-limited igdb metadata fetching
</blockquote>

## `retrom-plugin-installer`
<blockquote>

## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-plugin-installer-v0.0.8...retrom-plugin-installer-v0.0.9) - 2024-07-31

### Fixed
- rate-limited igdb metadata fetching
</blockquote>

## `retrom-plugin-launcher`
<blockquote>

## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.9...retrom-plugin-launcher-v0.0.10) - 2024-07-31

### Fixed
- rate-limited igdb metadata fetching
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.8...retrom-service-v0.0.9) - 2024-07-31

### Fixed
- rate-limited igdb metadata fetching
</blockquote>

## `retrom`
<blockquote>

## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.11...retrom-v0.0.12) - 2024-07-31

### Added
- web client ssl

### Fixed
- rendering issues
- rate-limited igdb metadata fetching
- publish
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).