### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.12...retrom-v0.0.13) - 2024-07-31
+
+### Fixed
+- client env-vars
+
+### Other
+- fix action trigger pattern
+
 ## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.11...retrom-v0.0.12) - 2024-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,11 +3711,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.12"
+version = "0.0.13"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "async-compression",
  "bb8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.12"
+version = "0.0.13"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,7 +44,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.8" }
-retrom-client = { path = "./packages/client", version = "0.0.11" }
+retrom-client = { path = "./packages/client", version = "0.0.12" }
 retrom-service = { path = "./packages/service", version = "0.0.9" }
 retrom-codegen = { path = "./packages/codegen", version = "0.0.9" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.11...retrom-client-v0.0.12) - 2024-07-31
+
+### Fixed
+- client env-vars
+
 ## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.10...retrom-client-v0.0.11) - 2024-07-31
 
 ### Added

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.11"
+version = "0.0.12"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.11 -> 0.0.12
* `retrom`: 0.0.12 -> 0.0.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.11...retrom-client-v0.0.12) - 2024-07-31

### Fixed
- client env-vars
</blockquote>

## `retrom`
<blockquote>

## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.12...retrom-v0.0.13) - 2024-07-31

### Fixed
- client env-vars

### Other
- fix action trigger pattern
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).