### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.14...retrom-v0.0.15) - 2024-07-31
+
+### Fixed
+- client runtime env
+
 ## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.13...retrom-v0.0.14) - 2024-07-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,11 +3711,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.14"
+version = "0.0.15"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "async-compression",
  "bb8",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.14"
+version = "0.0.15"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -43,8 +43,8 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "0.0.8" }
-retrom-client = { path = "./packages/client", version = "0.0.13" }
+retrom-db = { path = "./packages/db", version = "0.0.9" }
+retrom-client = { path = "./packages/client", version = "0.0.14" }
 retrom-service = { path = "./packages/service", version = "0.0.9" }
 retrom-codegen = { path = "./packages/codegen", version = "0.0.9" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.13...retrom-client-v0.0.14) - 2024-07-31
+
+### Fixed
+- client runtime env
+
 ## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.12...retrom-client-v0.0.13) - 2024-07-31
 
 ### Fixed

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.13"
+version = "0.0.14"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.8...retrom-db-v0.0.9) - 2024-07-31
+
+### Fixed
+- client runtime env

--- a/packages/db/Cargo.toml
+++ b/packages/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retrom-db"
 description = "Database layer for Retrom"
-version = "0.0.8"
+version = "0.0.9"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.13 -> 0.0.14
* `retrom-db`: 0.0.8 -> 0.0.9
* `retrom`: 0.0.14 -> 0.0.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.13...retrom-client-v0.0.14) - 2024-07-31

### Fixed
- client runtime env
</blockquote>

## `retrom-db`
<blockquote>

## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.8...retrom-db-v0.0.9) - 2024-07-31

### Fixed
- client runtime env
</blockquote>

## `retrom`
<blockquote>

## [0.0.15](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.14...retrom-v0.0.15) - 2024-07-31

### Fixed
- client runtime env
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).