### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.17](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.16...retrom-v0.0.17) - 2024-08-02
+
+### Other
+- updated the following local packages: retrom-client, retrom-service
+
 ## [0.0.16](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.15...retrom-v0.0.16) - 2024-08-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,11 +3711,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.16"
+version = "0.0.17"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "async-compression",
  "bb8",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.16"
+version = "0.0.17"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,8 +44,8 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.9" }
-retrom-client = { path = "./packages/client", version = "0.0.15" }
-retrom-service = { path = "./packages/service", version = "0.0.10" }
+retrom-client = { path = "./packages/client", version = "0.0.16" }
+retrom-service = { path = "./packages/service", version = "0.0.11" }
 retrom-codegen = { path = "./packages/codegen", version = "0.0.9" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }
 retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.10" }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.15...retrom-client-v0.0.16) - 2024-08-02
+
+### Added
+- much better IGDB auto-searching
+
+### Fixed
+- remove console logs
+
 ## [0.0.15](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.14...retrom-client-v0.0.15) - 2024-08-01
 
 ### Fixed

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.15"
+version = "0.0.16"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.10...retrom-service-v0.0.11) - 2024-08-02
+
+### Added
+- much better IGDB auto-searching
+
+### Fixed
+- remove console logs
+
 ## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.9...retrom-service-v0.0.10) - 2024-08-01
 
 ### Other

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-service"
-version = "0.0.10"
+version = "0.0.11"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.15 -> 0.0.16
* `retrom-service`: 0.0.10 -> 0.0.11
* `retrom`: 0.0.16 -> 0.0.17

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.16](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.15...retrom-client-v0.0.16) - 2024-08-02

### Added
- much better IGDB auto-searching

### Fixed
- remove console logs
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.10...retrom-service-v0.0.11) - 2024-08-02

### Added
- much better IGDB auto-searching

### Fixed
- remove console logs
</blockquote>

## `retrom`
<blockquote>

## [0.0.17](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.16...retrom-v0.0.17) - 2024-08-02

### Other
- updated the following local packages: retrom-client, retrom-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).