### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.19](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.18...retrom-v0.0.19) - 2024-08-04
+
+### Other
+- updated the following local packages: retrom-client, retrom-codegen
+
 ## [0.0.18](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.17...retrom-v0.0.18) - 2024-08-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,11 +3711,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.18"
+version = "0.0.19"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "async-compression",
  "bb8",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "diesel",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.18"
+version = "0.0.19"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,9 +44,9 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.9" }
-retrom-client = { path = "./packages/client", version = "0.0.17" }
+retrom-client = { path = "./packages/client", version = "0.0.18" }
 retrom-service = { path = "./packages/service", version = "0.0.12" }
-retrom-codegen = { path = "./packages/codegen", version = "0.0.10" }
+retrom-codegen = { path = "./packages/codegen", version = "0.0.11" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }
 retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.10" }
 futures = "0.3.30"

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.18](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.17...retrom-client-v0.0.18) - 2024-08-04
+
+### Fixed
+- config menu form handling
+
 ## [0.0.17](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.16...retrom-client-v0.0.17) - 2024-08-04
 
 ### Added

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.17"
+version = "0.0.18"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.10...retrom-codegen-v0.0.11) - 2024-08-04
+
+### Fixed
+- config menu form handling
+
 ## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.9...retrom-codegen-v0.0.10) - 2024-08-04
 
 ### Added

--- a/packages/codegen/Cargo.toml
+++ b/packages/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-codegen"
-version = "0.0.10"
+version = "0.0.11"
 description = "Code generation for Retrom"
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.17 -> 0.0.18
* `retrom-codegen`: 0.0.10 -> 0.0.11
* `retrom`: 0.0.18 -> 0.0.19

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.18](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.17...retrom-client-v0.0.18) - 2024-08-04

### Fixed
- config menu form handling
</blockquote>

## `retrom-codegen`
<blockquote>

## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.10...retrom-codegen-v0.0.11) - 2024-08-04

### Fixed
- config menu form handling
</blockquote>

## `retrom`
<blockquote>

## [0.0.19](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.18...retrom-v0.0.19) - 2024-08-04

### Other
- updated the following local packages: retrom-client, retrom-codegen
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).