### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.20](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.19...retrom-v0.0.20) - 2024-08-04
+
+### Other
+- updated the following local packages: retrom-client, retrom-service
+
 ## [0.0.19](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.18...retrom-v0.0.19) - 2024-08-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,11 +3711,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.19"
+version = "0.0.20"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "async-compression",
  "bb8",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.19"
+version = "0.0.20"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,8 +44,8 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.9" }
-retrom-client = { path = "./packages/client", version = "0.0.18" }
-retrom-service = { path = "./packages/service", version = "0.0.12" }
+retrom-client = { path = "./packages/client", version = "0.0.19" }
+retrom-service = { path = "./packages/service", version = "0.0.13" }
 retrom-codegen = { path = "./packages/codegen", version = "0.0.11" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }
 retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.10" }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.19](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.18...retrom-client-v0.0.19) - 2024-08-04
+
+### Added
+- add action button to game lists on home page
+- add general info component
+
 ## [0.0.18](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.17...retrom-client-v0.0.18) - 2024-08-04
 
 ### Fixed

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.18"
+version = "0.0.19"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.12...retrom-service-v0.0.13) - 2024-08-04
+
+### Fixed
+- re-scanning library finds new entries
+
 ## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.11...retrom-service-v0.0.12) - 2024-08-04
 
 ### Other

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-service"
-version = "0.0.12"
+version = "0.0.13"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.18 -> 0.0.19
* `retrom-service`: 0.0.12 -> 0.0.13
* `retrom`: 0.0.19 -> 0.0.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.19](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.18...retrom-client-v0.0.19) - 2024-08-04

### Added
- add action button to game lists on home page
- add general info component
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.12...retrom-service-v0.0.13) - 2024-08-04

### Fixed
- re-scanning library finds new entries
</blockquote>

## `retrom`
<blockquote>

## [0.0.20](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.19...retrom-v0.0.20) - 2024-08-04

### Other
- updated the following local packages: retrom-client, retrom-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).