### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.21](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.20...retrom-v0.0.21) - 2024-08-05
+
+### Other
+- updated the following local packages: retrom-client, retrom-codegen, retrom-db, retrom-service
+
 ## [0.0.20](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.19...retrom-v0.0.20) - 2024-08-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,11 +3711,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.20"
+version = "0.0.21"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "async-compression",
  "bb8",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "diesel",
  "prost",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.20"
+version = "0.0.21"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -43,10 +43,10 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "0.0.9" }
-retrom-client = { path = "./packages/client", version = "0.0.19" }
-retrom-service = { path = "./packages/service", version = "0.0.13" }
-retrom-codegen = { path = "./packages/codegen", version = "0.0.11" }
+retrom-db = { path = "./packages/db", version = "0.0.10" }
+retrom-client = { path = "./packages/client", version = "0.0.20" }
+retrom-service = { path = "./packages/service", version = "0.0.14" }
+retrom-codegen = { path = "./packages/codegen", version = "0.0.12" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }
 retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.10" }
 futures = "0.3.30"

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.20](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.19...retrom-client-v0.0.20) - 2024-08-05
+
+### Fixed
+- game file size overflow issues
+
 ## [0.0.19](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.18...retrom-client-v0.0.19) - 2024-08-04
 
 ### Added

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.19"
+version = "0.0.20"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.11...retrom-codegen-v0.0.12) - 2024-08-05
+
+### Fixed
+- game file size overflow issues
+
 ## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.10...retrom-codegen-v0.0.11) - 2024-08-04
 
 ### Fixed

--- a/packages/codegen/Cargo.toml
+++ b/packages/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-codegen"
-version = "0.0.11"
+version = "0.0.12"
 description = "Code generation for Retrom"
 authors.workspace = true
 repository.workspace = true

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.9...retrom-db-v0.0.10) - 2024-08-05
+
+### Fixed
+- game file size overflow issues
+
 ## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.8...retrom-db-v0.0.9) - 2024-07-31
 
 ### Fixed

--- a/packages/db/Cargo.toml
+++ b/packages/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retrom-db"
 description = "Database layer for Retrom"
-version = "0.0.9"
+version = "0.0.10"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.13...retrom-service-v0.0.14) - 2024-08-05
+
+### Fixed
+- game file size overflow issues
+
 ## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.12...retrom-service-v0.0.13) - 2024-08-04
 
 ### Fixed

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-service"
-version = "0.0.13"
+version = "0.0.14"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.19 -> 0.0.20
* `retrom-codegen`: 0.0.11 -> 0.0.12
* `retrom-db`: 0.0.9 -> 0.0.10
* `retrom-service`: 0.0.13 -> 0.0.14
* `retrom`: 0.0.20 -> 0.0.21

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.20](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.19...retrom-client-v0.0.20) - 2024-08-05

### Fixed
- game file size overflow issues
</blockquote>

## `retrom-codegen`
<blockquote>

## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.11...retrom-codegen-v0.0.12) - 2024-08-05

### Fixed
- game file size overflow issues
</blockquote>

## `retrom-db`
<blockquote>

## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.9...retrom-db-v0.0.10) - 2024-08-05

### Fixed
- game file size overflow issues
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.13...retrom-service-v0.0.14) - 2024-08-05

### Fixed
- game file size overflow issues
</blockquote>

## `retrom`
<blockquote>

## [0.0.21](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.20...retrom-v0.0.21) - 2024-08-05

### Other
- updated the following local packages: retrom-client, retrom-codegen, retrom-db, retrom-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).