### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.23](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.22...retrom-v0.0.23) - 2024-08-13
+
+### Added
+- nextjs node server as sidecar
+
+### Fixed
+- lazy-connect to service
+
+### Other
+- setup pnpm
+- only build tauri on release
+- build client binaries
+
 ## [0.0.22](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.21...retrom-v0.0.22) - 2024-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,11 +3744,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.22"
+version = "0.0.23"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "async-compression",
  "bb8",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "dotenvy",
  "retrom-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.22"
+version = "0.0.23"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,11 +44,11 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.10" }
-retrom-client = { path = "./packages/client", version = "0.0.21" }
+retrom-client = { path = "./packages/client", version = "0.0.22" }
 retrom-service = { path = "./packages/service", version = "0.0.14" }
 retrom-codegen = { path = "./packages/codegen", version = "0.0.12" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.10" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.11" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.22](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.21...retrom-client-v0.0.22) - 2024-08-13
+
+### Added
+- nextjs node server as sidecar
+
+### Fixed
+- default macos builds now run
+
 ## [0.0.21](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.20...retrom-client-v0.0.21) - 2024-08-08
 
 ### Added

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.21"
+version = "0.0.22"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/plugins/retrom-plugin-launcher/CHANGELOG.md
+++ b/plugins/retrom-plugin-launcher/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.10...retrom-plugin-launcher-v0.0.11) - 2024-08-13
+
+### Fixed
+- lazy-connect to service
+- default macos builds now run
+
 ## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.9...retrom-plugin-launcher-v0.0.10) - 2024-07-31
 
 ### Fixed

--- a/plugins/retrom-plugin-launcher/Cargo.toml
+++ b/plugins/retrom-plugin-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-plugin-launcher"
-version = "0.0.10"
+version = "0.0.11"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.21 -> 0.0.22
* `retrom-plugin-launcher`: 0.0.10 -> 0.0.11
* `retrom`: 0.0.22 -> 0.0.23

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.22](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.21...retrom-client-v0.0.22) - 2024-08-13

### Added
- nextjs node server as sidecar

### Fixed
- default macos builds now run
</blockquote>

## `retrom-plugin-launcher`
<blockquote>

## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.10...retrom-plugin-launcher-v0.0.11) - 2024-08-13

### Fixed
- lazy-connect to service
- default macos builds now run
</blockquote>

## `retrom`
<blockquote>

## [0.0.23](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.22...retrom-v0.0.23) - 2024-08-13

### Added
- nextjs node server as sidecar

### Fixed
- lazy-connect to service

### Other
- setup pnpm
- only build tauri on release
- build client binaries
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).