### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.27](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.26...retrom-v0.0.27) - 2024-08-13
+
+### Fixed
+- re-build
+
 ## [0.0.26](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.25...retrom-v0.0.26) - 2024-08-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,11 +3735,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.26"
+version = "0.0.27"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "async-compression",
  "bb8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.26"
+version = "0.0.27"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,7 +44,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.10" }
-retrom-client = { path = "./packages/client", version = "0.0.25" }
+retrom-client = { path = "./packages/client", version = "0.0.26" }
 retrom-service = { path = "./packages/service", version = "0.0.14" }
 retrom-codegen = { path = "./packages/codegen", version = "0.0.12" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.26](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.25...retrom-client-v0.0.26) - 2024-08-13
+
+### Other
+- update Cargo.lock dependencies
+
 ## [0.0.25](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.24...retrom-client-v0.0.25) - 2024-08-13
 
 ### Other

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.25"
+version = "0.0.26"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.25 -> 0.0.26
* `retrom`: 0.0.26 -> 0.0.27

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.26](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.25...retrom-client-v0.0.26) - 2024-08-13

### Other
- update Cargo.lock dependencies
</blockquote>

## `retrom`
<blockquote>

## [0.0.27](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.26...retrom-v0.0.27) - 2024-08-13

### Fixed
- re-build
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).