### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.36](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.35...retrom-v0.0.36) - 2024-08-13
+
+### Other
+- remove db deps from client
+
 ## [0.0.35](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.34...retrom-v0.0.35) - 2024-08-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,11 +3735,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.35"
+version = "0.0.36"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "dotenvy",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.35"
+version = "0.0.36"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,10 +44,10 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "0.0.10" }
-retrom-client = { path = "./packages/client", version = "0.0.34" }
+retrom-client = { path = "./packages/client", version = "0.0.35" }
 retrom-service = { path = "./packages/service", version = "0.0.14" }
 retrom-codegen = { path = "./packages/codegen", version = "0.0.12" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.9" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.10" }
 retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.11" }
 futures = "0.3.30"
 bytes = "1.6.0"

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.35](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.34...retrom-client-v0.0.35) - 2024-08-13
+
+### Other
+- remove db deps from client
+
 ## [0.0.34](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.33...retrom-client-v0.0.34) - 2024-08-13
 
 ### Fixed

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.34"
+version = "0.0.35"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/plugins/retrom-plugin-installer/CHANGELOG.md
+++ b/plugins/retrom-plugin-installer/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-plugin-installer-v0.0.9...retrom-plugin-installer-v0.0.10) - 2024-08-13
+
+### Other
+- remove db deps from client
+
 ## [0.0.9](https://github.com/JMBeresford/retrom/compare/retrom-plugin-installer-v0.0.8...retrom-plugin-installer-v0.0.9) - 2024-07-31
 
 ### Fixed

--- a/plugins/retrom-plugin-installer/Cargo.toml
+++ b/plugins/retrom-plugin-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-plugin-installer"
-version = "0.0.9"
+version = "0.0.10"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.34 -> 0.0.35
* `retrom-plugin-installer`: 0.0.9 -> 0.0.10
* `retrom`: 0.0.35 -> 0.0.36

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.35](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.34...retrom-client-v0.0.35) - 2024-08-13

### Other
- remove db deps from client
</blockquote>

## `retrom-plugin-installer`
<blockquote>

## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-plugin-installer-v0.0.9...retrom-plugin-installer-v0.0.10) - 2024-08-13

### Other
- remove db deps from client
</blockquote>

## `retrom`
<blockquote>

## [0.0.36](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.35...retrom-v0.0.36) - 2024-08-13

### Other
- remove db deps from client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).