### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,7 +3739,7 @@ version = "0.0.43"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.38"
+version = "0.0.39"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "diesel",
  "prost",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "dotenvy",
  "retrom-codegen",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.0.10" }
-retrom-client = { path = "./packages/client", version = "^0.0.38" }
-retrom-service = { path = "./packages/service", version = "^0.0.14" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.0.12" }
+retrom-db = { path = "./packages/db", version = "^0.0.11" }
+retrom-client = { path = "./packages/client", version = "^0.0.39" }
+retrom-service = { path = "./packages/service", version = "^0.0.15" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.0.13" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.0.11" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.0.12" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.0.13" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.39](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.38...retrom-client-v0.0.39) - 2024-08-18
+
+### Added
+- setup wizard
+
+### Fixed
+- macOS adhoc signing
+- macOS adhoc signing
+
+### Other
+- Update build.rs
+- Update build.rs
+
 ## [0.0.38](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.37...retrom-client-v0.0.38) - 2024-08-14
 
 ### Other

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.38"
+version = "0.0.39"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.12...retrom-codegen-v0.0.13) - 2024-08-18
+
+### Added
+- setup wizard
+
 ## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.11...retrom-codegen-v0.0.12) - 2024-08-05
 
 ### Fixed

--- a/packages/codegen/Cargo.toml
+++ b/packages/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-codegen"
-version = "0.0.12"
+version = "0.0.13"
 description = "Code generation for Retrom"
 authors.workspace = true
 repository.workspace = true

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.10...retrom-db-v0.0.11) - 2024-08-18
+
+### Added
+- setup wizard
+
 ## [0.0.10](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.9...retrom-db-v0.0.10) - 2024-08-05
 
 ### Fixed

--- a/packages/db/Cargo.toml
+++ b/packages/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retrom-db"
 description = "Database layer for Retrom"
-version = "0.0.10"
+version = "0.0.11"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.14...retrom-service-v0.0.15) - 2024-08-18
+
+### Added
+- setup wizard
+
 ## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.13...retrom-service-v0.0.14) - 2024-08-05
 
 ### Fixed

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-service"
-version = "0.0.14"
+version = "0.0.15"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/plugins/retrom-plugin-launcher/CHANGELOG.md
+++ b/plugins/retrom-plugin-launcher/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.12...retrom-plugin-launcher-v0.0.13) - 2024-08-18
+
+### Added
+- setup wizard
+
 ## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.11...retrom-plugin-launcher-v0.0.12) - 2024-08-13
 
 ### Other

--- a/plugins/retrom-plugin-launcher/Cargo.toml
+++ b/plugins/retrom-plugin-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-plugin-launcher"
-version = "0.0.12"
+version = "0.0.13"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.38 -> 0.0.39
* `retrom-codegen`: 0.0.12 -> 0.0.13
* `retrom-db`: 0.0.10 -> 0.0.11
* `retrom-plugin-launcher`: 0.0.12 -> 0.0.13
* `retrom-service`: 0.0.14 -> 0.0.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.39](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.38...retrom-client-v0.0.39) - 2024-08-18

### Added
- setup wizard

### Fixed
- macOS adhoc signing
- macOS adhoc signing

### Other
- Update build.rs
- Update build.rs
</blockquote>

## `retrom-codegen`
<blockquote>

## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.12...retrom-codegen-v0.0.13) - 2024-08-18

### Added
- setup wizard
</blockquote>

## `retrom-db`
<blockquote>

## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.10...retrom-db-v0.0.11) - 2024-08-18

### Added
- setup wizard
</blockquote>

## `retrom-plugin-launcher`
<blockquote>

## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-plugin-launcher-v0.0.12...retrom-plugin-launcher-v0.0.13) - 2024-08-18

### Added
- setup wizard
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.15](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.14...retrom-service-v0.0.15) - 2024-08-18

### Added
- setup wizard
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).