### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.46](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.45...retrom-v0.0.46) - 2024-08-19
+
+### Other
+- updated the following local packages: retrom-client
+
 ## [0.0.45](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.44...retrom-v0.0.45) - 2024-08-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,11 +3735,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.45"
+version = "0.0.46"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "async-compression",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.45"
+version = "0.0.46"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,7 +44,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "^0.0.11" }
-retrom-client = { path = "./packages/client", version = "^0.0.41" }
+retrom-client = { path = "./packages/client", version = "^0.0.42" }
 retrom-service = { path = "./packages/service", version = "^0.0.15" }
 retrom-codegen = { path = "./packages/codegen", version = "^0.0.13" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.0.11" }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.42](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.41...retrom-client-v0.0.42) - 2024-08-19
+
+### Other
+- fix targets
+
 ## [0.0.41](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.40...retrom-client-v0.0.41) - 2024-08-18
 
 ### Fixed

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.41"
+version = "0.0.42"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.41 -> 0.0.42
* `retrom`: 0.0.45 -> 0.0.46

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.42](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.41...retrom-client-v0.0.42) - 2024-08-19

### Other
- fix targets
</blockquote>

## `retrom`
<blockquote>

## [0.0.46](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.45...retrom-v0.0.46) - 2024-08-19

### Other
- updated the following local packages: retrom-client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).