### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.47](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.46...retrom-v0.0.47) - 2024-08-21
+
+### Other
+- updated the following local packages: retrom-client, retrom-codegen, retrom-db, retrom-service
+
 ## [0.0.46](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.45...retrom-v0.0.46) - 2024-08-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,11 +3735,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.46"
+version = "0.0.47"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "diesel",
  "prost",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.46"
+version = "0.0.47"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -43,10 +43,10 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.0.11" }
-retrom-client = { path = "./packages/client", version = "^0.0.42" }
-retrom-service = { path = "./packages/service", version = "^0.0.15" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.0.13" }
+retrom-db = { path = "./packages/db", version = "^0.0.12" }
+retrom-client = { path = "./packages/client", version = "^0.0.43" }
+retrom-service = { path = "./packages/service", version = "^0.0.16" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.0.14" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.0.11" }
 retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.0.13" }
 futures = "0.3.30"

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.43](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.42...retrom-client-v0.0.43) - 2024-08-21
+
+### Added
+- deletion + renaming of models
+
+### Fixed
+- config menu item now submits
+
 ## [0.0.42](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.41...retrom-client-v0.0.42) - 2024-08-19
 
 ### Other

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.42"
+version = "0.0.43"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.13...retrom-codegen-v0.0.14) - 2024-08-21
+
+### Added
+- deletion + renaming of models
+
 ## [0.0.13](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.12...retrom-codegen-v0.0.13) - 2024-08-18
 
 ### Added

--- a/packages/codegen/Cargo.toml
+++ b/packages/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-codegen"
-version = "0.0.13"
+version = "0.0.14"
 description = "Code generation for Retrom"
 authors.workspace = true
 repository.workspace = true

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.11...retrom-db-v0.0.12) - 2024-08-21
+
+### Added
+- deletion + renaming of models
+
 ## [0.0.11](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.10...retrom-db-v0.0.11) - 2024-08-18
 
 ### Added

--- a/packages/db/Cargo.toml
+++ b/packages/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retrom-db"
 description = "Database layer for Retrom"
-version = "0.0.11"
+version = "0.0.12"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.15...retrom-service-v0.0.16) - 2024-08-21
+
+### Added
+- deletion + renaming of models
+
 ## [0.0.15](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.14...retrom-service-v0.0.15) - 2024-08-18
 
 ### Added

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-service"
-version = "0.0.15"
+version = "0.0.16"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.42 -> 0.0.43
* `retrom-codegen`: 0.0.13 -> 0.0.14
* `retrom-db`: 0.0.11 -> 0.0.12
* `retrom-service`: 0.0.15 -> 0.0.16
* `retrom`: 0.0.46 -> 0.0.47

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.43](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.42...retrom-client-v0.0.43) - 2024-08-21

### Added
- deletion + renaming of models

### Fixed
- config menu item now submits
</blockquote>

## `retrom-codegen`
<blockquote>

## [0.0.14](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.13...retrom-codegen-v0.0.14) - 2024-08-21

### Added
- deletion + renaming of models
</blockquote>

## `retrom-db`
<blockquote>

## [0.0.12](https://github.com/JMBeresford/retrom/compare/retrom-db-v0.0.11...retrom-db-v0.0.12) - 2024-08-21

### Added
- deletion + renaming of models
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.16](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.15...retrom-service-v0.0.16) - 2024-08-21

### Added
- deletion + renaming of models
</blockquote>

## `retrom`
<blockquote>

## [0.0.47](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.46...retrom-v0.0.47) - 2024-08-21

### Other
- updated the following local packages: retrom-client, retrom-codegen, retrom-db, retrom-service
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).