### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.49](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.48...retrom-v0.0.49) - 2024-08-26
+
+### Added
+- dependent bg jobs
+
+### Fixed
+- renaming path entries
+
 ## [0.0.48](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.47...retrom-v0.0.48) - 2024-08-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,11 +3735,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.48"
+version = "0.0.49"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "diesel",
  "prost",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.48"
+version = "0.0.49"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,9 +44,9 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "^0.0.12" }
-retrom-client = { path = "./packages/client", version = "^0.0.44" }
-retrom-service = { path = "./packages/service", version = "^0.0.17" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.0.15" }
+retrom-client = { path = "./packages/client", version = "^0.0.45" }
+retrom-service = { path = "./packages/service", version = "^0.0.18" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.0.16" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.0.11" }
 retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.0.13" }
 futures = "0.3.30"

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.45](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.44...retrom-client-v0.0.45) - 2024-08-26
+
+### Added
+- dependent bg jobs
+
 ## [0.0.44](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.43...retrom-client-v0.0.44) - 2024-08-25
 
 ### Added

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.44"
+version = "0.0.45"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.15...retrom-codegen-v0.0.16) - 2024-08-26
+
+### Added
+- dependent bg jobs
+
 ## [0.0.15](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.14...retrom-codegen-v0.0.15) - 2024-08-25
 
 ### Added

--- a/packages/codegen/Cargo.toml
+++ b/packages/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-codegen"
-version = "0.0.15"
+version = "0.0.16"
 description = "Code generation for Retrom"
 authors.workspace = true
 repository.workspace = true

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.18](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.17...retrom-service-v0.0.18) - 2024-08-26
+
+### Added
+- dependent bg jobs
+
+### Fixed
+- renaming path entries
+
 ## [0.0.17](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.16...retrom-service-v0.0.17) - 2024-08-25
 
 ### Added

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-service"
-version = "0.0.17"
+version = "0.0.18"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.44 -> 0.0.45
* `retrom-codegen`: 0.0.15 -> 0.0.16
* `retrom-service`: 0.0.17 -> 0.0.18
* `retrom`: 0.0.48 -> 0.0.49

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.45](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.44...retrom-client-v0.0.45) - 2024-08-26

### Added
- dependent bg jobs
</blockquote>

## `retrom-codegen`
<blockquote>

## [0.0.16](https://github.com/JMBeresford/retrom/compare/retrom-codegen-v0.0.15...retrom-codegen-v0.0.16) - 2024-08-26

### Added
- dependent bg jobs
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.18](https://github.com/JMBeresford/retrom/compare/retrom-service-v0.0.17...retrom-service-v0.0.18) - 2024-08-26

### Added
- dependent bg jobs

### Fixed
- renaming path entries
</blockquote>

## `retrom`
<blockquote>

## [0.0.49](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.48...retrom-v0.0.49) - 2024-08-26

### Added
- dependent bg jobs

### Fixed
- renaming path entries
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).