### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.50](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.49...retrom-v0.0.50) - 2024-08-26
+
+### Other
+- Update README.md
+
 ## [0.0.49](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.48...retrom-v0.0.49) - 2024-08-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,11 +3735,11 @@ dependencies = [
 
 [[package]]
 name = "retrom"
-version = "0.0.49"
+version = "0.0.50"
 
 [[package]]
 name = "retrom-client"
-version = "0.0.45"
+version = "0.0.46"
 dependencies = [
  "async-compression",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules"]
 
 [package]
 name = "retrom"
-version = "0.0.49"
+version = "0.0.50"
 description = "Retrom is a centralized game library/collection management service with a focus on emulation."
 edition.workspace = true
 authors.workspace = true
@@ -44,7 +44,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
 retrom-db = { path = "./packages/db", version = "^0.0.12" }
-retrom-client = { path = "./packages/client", version = "^0.0.45" }
+retrom-client = { path = "./packages/client", version = "^0.0.46" }
 retrom-service = { path = "./packages/service", version = "^0.0.18" }
 retrom-codegen = { path = "./packages/codegen", version = "^0.0.16" }
 retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.0.11" }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.46](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.45...retrom-client-v0.0.46) - 2024-08-26
+
+### Fixed
+- sidebar active game highlight
+
 ## [0.0.45](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.44...retrom-client-v0.0.45) - 2024-08-26
 
 ### Added

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retrom-client"
-version = "0.0.45"
+version = "0.0.46"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.45 -> 0.0.46
* `retrom`: 0.0.49 -> 0.0.50

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.46](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.45...retrom-client-v0.0.46) - 2024-08-26

### Fixed
- sidebar active game highlight
</blockquote>

## `retrom`
<blockquote>

## [0.0.50](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.49...retrom-v0.0.50) - 2024-08-26

### Other
- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).