### PR TITLE
chore: release v0.0.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.56](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.55...retrom-client-v0.0.56) - 2024-09-02
+
+### Added
+- update toast does not dismiss
+
 ## `retrom-service` - [0.0.54](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.53...retrom-v0.0.54) - 2024-09-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "diesel",
  "prost",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "dotenvy",
  "futures",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "dotenvy",
  "retrom-codegen",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.0.55"
+version = "0.0.56"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "0.0.55" }
-retrom-client = { path = "./packages/client", version = "0.0.55" }
-retrom-service = { path = "./packages/service", version = "0.0.55" }
-retrom-codegen = { path = "./packages/codegen", version = "0.0.55" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.55" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.55" }
+retrom-db = { path = "./packages/db", version = "0.0.56" }
+retrom-client = { path = "./packages/client", version = "0.0.56" }
+retrom-service = { path = "./packages/service", version = "0.0.56" }
+retrom-codegen = { path = "./packages/codegen", version = "0.0.56" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.56" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.56" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.55 -> 0.0.56
* `retrom-codegen`: 0.0.55 -> 0.0.56
* `retrom-db`: 0.0.55 -> 0.0.56
* `retrom-plugin-installer`: 0.0.55 -> 0.0.56
* `retrom-plugin-launcher`: 0.0.55 -> 0.0.56
* `retrom-service`: 0.0.55 -> 0.0.56

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-client`
<blockquote>

## [0.0.56](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.55...retrom-client-v0.0.56) - 2024-09-02

### Added
- update toast does not dismiss
</blockquote>

## `retrom-service`
<blockquote>

## [0.0.56](https://github.com/JMBeresford/retrom/compare/retrom-client-v0.0.55...retrom-client-v0.0.56) - 2024-09-02

### Added
- update toast does not dismiss
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).