### PR TITLE
chore: release v0.0.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.75](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.74...retrom-v0.0.75) - 2024-09-13
+
+### Fixed
+
+- doc links + UI tweaks
+
 ## [0.0.74](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.73...retrom-v0.0.74) - 2024-09-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "diesel",
  "prost",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "dotenvy",
  "futures",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "dotenvy",
  "retrom-codegen",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.74"
+version = "0.0.75"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.0.74"
+version = "0.0.75"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "0.0.74" }
-retrom-client = { path = "./packages/client", version = "0.0.74" }
-retrom-service = { path = "./packages/service", version = "0.0.74" }
-retrom-codegen = { path = "./packages/codegen", version = "0.0.74" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.74" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.74" }
+retrom-db = { path = "./packages/db", version = "0.0.75" }
+retrom-client = { path = "./packages/client", version = "0.0.75" }
+retrom-service = { path = "./packages/service", version = "0.0.75" }
+retrom-codegen = { path = "./packages/codegen", version = "0.0.75" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.75" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.75" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.74 -> 0.0.75
* `retrom-codegen`: 0.0.74 -> 0.0.75
* `retrom-db`: 0.0.74 -> 0.0.75
* `retrom-plugin-installer`: 0.0.74 -> 0.0.75
* `retrom-plugin-launcher`: 0.0.74 -> 0.0.75
* `retrom-service`: 0.0.74 -> 0.0.75

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.0.75](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.74...retrom-v0.0.75) - 2024-09-13

### Fixed

- doc links + UI tweaks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).