### PR TITLE
chore: release v0.0.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.80](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.79...retrom-v0.0.80) - 2024-09-18
+
+### Fixed
+
+- custom arg parsing
+- emulator profile modal width
+
 ## [0.0.79](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.78...retrom-v0.0.79) - 2024-09-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "diesel",
  "prost",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "dotenvy",
  "futures",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.79"
+version = "0.0.80"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.0.79"
+version = "0.0.80"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "0.0.79" }
-retrom-client = { path = "./packages/client", version = "0.0.79" }
-retrom-service = { path = "./packages/service", version = "0.0.79" }
-retrom-codegen = { path = "./packages/codegen", version = "0.0.79" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.79" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.79" }
+retrom-db = { path = "./packages/db", version = "0.0.80" }
+retrom-client = { path = "./packages/client", version = "0.0.80" }
+retrom-service = { path = "./packages/service", version = "0.0.80" }
+retrom-codegen = { path = "./packages/codegen", version = "0.0.80" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "0.0.80" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "0.0.80" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.79 -> 0.0.80
* `retrom-codegen`: 0.0.79 -> 0.0.80
* `retrom-db`: 0.0.79 -> 0.0.80
* `retrom-plugin-installer`: 0.0.79 -> 0.0.80
* `retrom-plugin-launcher`: 0.0.79 -> 0.0.80
* `retrom-service`: 0.0.79 -> 0.0.80

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.0.80](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.79...retrom-v0.0.80) - 2024-09-18

### Fixed

- custom arg parsing
- emulator profile modal width
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).