### PR TITLE
chore: release v0.0.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.81](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.80...retrom-v0.0.81) - 2024-09-22
+
+### Added
+
+- warn on breaking changes
+
 ## [0.0.80](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.79...retrom-v0.0.80) - 2024-09-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "diesel",
  "prost",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "dotenvy",
  "futures",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.0.80"
+version = "0.0.81"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.0.80 -> 0.0.81
* `retrom-service`: 0.0.80 -> 0.0.81

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.0.81](https://github.com/JMBeresford/retrom/compare/retrom-v0.0.80...retrom-v0.0.81) - 2024-09-22

### Added

- warn on breaking changes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).