### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.1...retrom-v0.1.2) - 2024-09-24
+
+### Fixed
+
+- fallback to deprecated CONTENT_DIR envvar
+- sidebar sorting
+
 ## [0.1.1](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.0...retrom-v0.1.1) - 2024-09-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "diesel",
  "prost",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bb8",
@@ -4102,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bb8",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.1.1" }
-retrom-client = { path = "./packages/client", version = "^0.1.1" }
-retrom-service = { path = "./packages/service", version = "^0.1.1" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.1.1" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.1.1" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.1.1" }
+retrom-db = { path = "./packages/db", version = "^0.1.2" }
+retrom-client = { path = "./packages/client", version = "^0.1.2" }
+retrom-service = { path = "./packages/service", version = "^0.1.2" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.1.2" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.1.2" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.1.2" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.1.1 -> 0.1.2
* `retrom-codegen`: 0.1.1 -> 0.1.2
* `retrom-db`: 0.1.1 -> 0.1.2
* `retrom-plugin-installer`: 0.1.1 -> 0.1.2
* `retrom-plugin-launcher`: 0.1.1 -> 0.1.2
* `retrom-service`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.1.2](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.1...retrom-v0.1.2) - 2024-09-24

### Fixed

- fallback to deprecated CONTENT_DIR envvar
- sidebar sorting
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).