### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.6...retrom-v0.1.7) - 2024-09-26
+
+### Added
+
+- *(client)* opt-out of platform filtering in IGDB searching
+
+### Fixed
+
+- *(service)* no longer relies on default config file
+- *(client)* render single-file game names with dots
+- *(client)* render multi-file game names with dots
+
 ## [0.1.6](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.5...retrom-v0.1.6) - 2024-09-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "diesel",
  "prost",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.1.6" }
-retrom-client = { path = "./packages/client", version = "^0.1.6" }
-retrom-service = { path = "./packages/service", version = "^0.1.6" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.1.6" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.1.6" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.1.6" }
+retrom-db = { path = "./packages/db", version = "^0.1.7" }
+retrom-client = { path = "./packages/client", version = "^0.1.7" }
+retrom-service = { path = "./packages/service", version = "^0.1.7" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.1.7" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.1.7" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.1.7" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.1.6 -> 0.1.7
* `retrom-codegen`: 0.1.6 -> 0.1.7
* `retrom-db`: 0.1.6 -> 0.1.7
* `retrom-plugin-installer`: 0.1.6 -> 0.1.7
* `retrom-plugin-launcher`: 0.1.6 -> 0.1.7
* `retrom-service`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.1.7](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.6...retrom-v0.1.7) - 2024-09-26

### Added

- *(client)* opt-out of platform filtering in IGDB searching

### Fixed

- *(service)* no longer relies on default config file
- *(client)* render single-file game names with dots
- *(client)* render multi-file game names with dots
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).