### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.9...retrom-v0.1.10) - 2024-09-27
+
+### Added
+
+- web client bundled with service docker image ([#134](https://github.com/JMBeresford/retrom/pull/134))
+
 ## [0.1.9](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.8...retrom-v0.1.9) - 2024-09-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "diesel",
  "prost",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.1.9" }
-retrom-client = { path = "./packages/client", version = "^0.1.9" }
-retrom-service = { path = "./packages/service", version = "^0.1.9" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.1.9" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.1.9" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.1.9" }
+retrom-db = { path = "./packages/db", version = "^0.1.10" }
+retrom-client = { path = "./packages/client", version = "^0.1.10" }
+retrom-service = { path = "./packages/service", version = "^0.1.10" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.1.10" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.1.10" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.1.10" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.1.9 -> 0.1.10
* `retrom-codegen`: 0.1.9 -> 0.1.10
* `retrom-db`: 0.1.9 -> 0.1.10
* `retrom-plugin-installer`: 0.1.9 -> 0.1.10
* `retrom-plugin-launcher`: 0.1.9 -> 0.1.10
* `retrom-service`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.1.10](https://github.com/JMBeresford/retrom/compare/retrom-v0.1.9...retrom-v0.1.10) - 2024-09-27

### Added

- web client bundled with service docker image ([#134](https://github.com/JMBeresford/retrom/pull/134))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).