### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.2.7](https://github.com/JMBeresford/retrom/compare/retrom-v0.2.6...retrom-v0.2.7) - 2024-10-17
+
+### Fixed
+- installed games filenames
+
+    Installing games now properly omit's any quotes that wrap the filename,
+    fixing the issue where games could not be installed on windows.
+
+    Additionally, filenames now no longer strip the file extension.
 ## [0.2.6](https://github.com/JMBeresford/retrom/compare/retrom-v0.2.5...retrom-v0.2.6) - 2024-10-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "diesel",
  "prost",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bigdecimal",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.2.6" }
-retrom-client = { path = "./packages/client", version = "^0.2.6" }
-retrom-service = { path = "./packages/service", version = "^0.2.6" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.2.6" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.2.6" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.2.6" }
+retrom-db = { path = "./packages/db", version = "^0.2.7" }
+retrom-client = { path = "./packages/client", version = "^0.2.7" }
+retrom-service = { path = "./packages/service", version = "^0.2.7" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.2.7" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.2.7" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.2.7" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.2.6 -> 0.2.7
* `retrom-codegen`: 0.2.6 -> 0.2.7
* `retrom-db`: 0.2.6 -> 0.2.7
* `retrom-plugin-installer`: 0.2.6 -> 0.2.7
* `retrom-plugin-launcher`: 0.2.6 -> 0.2.7
* `retrom-service`: 0.2.6 -> 0.2.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.2.7](https://github.com/JMBeresford/retrom/compare/retrom-v0.2.6...retrom-v0.2.7) - 2024-10-17

### Fixed
- installed games filenames

    Installing games now properly omit's any quotes that wrap the filename,
    fixing the issue where games could not be installed on windows.

    Additionally, filenames now no longer strip the file extension.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).