### PR TITLE
feat!: shared emulator profiles

### DIFF
--- a/packages/client/web/eslint.config.js
+++ b/packages/client/web/eslint.config.js
@@ -11,23 +11,23 @@ export default tseslint.config(
     extends: [
       js.configs.recommended,
       ...tanstackQuery.configs["flat/recommended"],
-      ...tseslint.configs.recommended,
+      ...tseslint.configs.recommended
     ],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: globals.browser
     },
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
-      "@tanstack/query": tanstackQuery,
+      "@tanstack/query": tanstackQuery
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": [
         "warn",
-        { allowConstantExport: true },
+        { allowConstantExport: true }
       ],
       "@typescript-eslint/no-unused-vars": [
         "error",
@@ -35,9 +35,10 @@ export default tseslint.config(
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",
-          destructuredArrayIgnorePattern: "^_",
-        },
+          destructuredArrayIgnorePattern: "^_"
+        }
       ],
-    },
-  },
+      "react-refresh/only-export-components": "off"
+    }
+  }
 );

--- a/packages/client/web/src/components/menubar/emulators-menu/index.tsx
+++ b/packages/client/web/src/components/menubar/emulators-menu/index.tsx
@@ -14,13 +14,13 @@ export function EmulatorsMenu() {
       </MenubarTrigger>
 
       <MenubarContent>
-        <MenubarItem>
+        <MenubarItem asChild>
           <Link search={{ manageEmulatorsModal: { open: true } }}>
             Manage Emulators
           </Link>
         </MenubarItem>
 
-        <MenubarItem>
+        <MenubarItem asChild>
           <Link search={{ manageEmulatorProfilesModal: { open: true } }}>
             Manage Profiles
           </Link>

--- a/packages/client/web/src/components/menubar/file-menu/config-menu-item.tsx
+++ b/packages/client/web/src/components/menubar/file-menu/config-menu-item.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 
 export function ConfigMenuItem() {
   return (
-    <MenubarItem>
+    <MenubarItem asChild>
       <Link search={{ setupModal: { open: true } }}>Connect To Server</Link>
     </MenubarItem>
   );

--- a/packages/client/web/src/components/modals/manage-emulators/local-configs.tsx
+++ b/packages/client/web/src/components/modals/manage-emulators/local-configs.tsx
@@ -1,0 +1,197 @@
+import { Button } from "@/components/ui/button";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Emulator,
+  LocalEmulatorConfig,
+} from "@/generated/retrom/models/emulators";
+import { cn } from "@/lib/utils";
+import { useCreateLocalEmulatorConfigs } from "@/mutations/useCreateLocalEmulatorConfig";
+import { useUpdateLocalEmulatorConfig } from "@/mutations/useUpdateLocalEmulatorConfigs";
+import { useConfig } from "@/providers/config";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { open } from "@tauri-apps/plugin-dialog";
+import { FolderOpenIcon, LoaderCircleIcon, SaveIcon } from "lucide-react";
+import { useCallback } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+type ConfigSchema = z.infer<typeof configSchema>;
+const configSchema = z.object({
+  executablePath: z.string().min(1),
+}) satisfies z.ZodObject<
+  Record<
+    keyof Omit<
+      LocalEmulatorConfig,
+      "createdAt" | "updatedAt" | "id" | "emulatorId" | "clientId" | "nickname"
+    >,
+    z.ZodType
+  >
+>;
+
+export function LocalConfigs(props: {
+  emulators: Emulator[];
+  configs: LocalEmulatorConfig[];
+}) {
+  return (
+    <>
+      <div className="grid grid-cols-[1fr_2fr_auto] grid-flow-col gap-y-2">
+        <div
+          className={cn(
+            "grid grid-cols-subgrid col-span-full grid-flow-col",
+            "text-sm *:font-bold",
+          )}
+        >
+          <Label>Emulator</Label>
+          <Label>Executable Path</Label>
+        </div>
+
+        {props.emulators.map((emulator) => {
+          const config = props.configs.find(
+            (c) => c.emulatorId === emulator.id,
+          );
+
+          return (
+            <LocalConfigRow
+              key={emulator.id}
+              emulator={emulator}
+              config={config}
+            />
+          );
+        })}
+      </div>
+
+      <DialogFooter className="border-none mt-8">
+        <div className="flex justify-end col-span-4 gap-4">
+          <DialogClose asChild>
+            <Button variant="secondary">Close</Button>
+          </DialogClose>
+        </div>
+      </DialogFooter>
+    </>
+  );
+}
+
+function LocalConfigRow(props: {
+  emulator: Emulator;
+  config?: LocalEmulatorConfig;
+}) {
+  const { emulator, config } = props;
+  const clientId = useConfig().getState().config.clientInfo.id;
+
+  const form = useForm<ConfigSchema>({
+    defaultValues: {
+      executablePath: config?.executablePath || "",
+    } satisfies Required<ConfigSchema>,
+    resolver: zodResolver(configSchema),
+  });
+
+  const { mutateAsync: createConfig, isPending: creationPending } =
+    useCreateLocalEmulatorConfigs();
+
+  const { mutateAsync: updateConfig, isPending: updatePending } =
+    useUpdateLocalEmulatorConfig();
+
+  const handleSubmit = useCallback(
+    async (values: ConfigSchema) => {
+      if (config) {
+        const res = await updateConfig({
+          configs: [
+            { ...values, id: config.id, clientId, emulatorId: emulator.id },
+          ],
+        });
+        form.reset(res.configsUpdated.at(0));
+        return;
+      } else {
+        const res = await createConfig({
+          configs: [{ ...values, clientId, emulatorId: emulator.id }],
+        });
+        form.reset(res.configsCreated.at(0));
+        return;
+      }
+    },
+    [config, createConfig, updateConfig, form, emulator, clientId],
+  );
+
+  const pending = creationPending || updatePending;
+  const { isDirty } = form.formState;
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        key={emulator.id}
+        className={cn(
+          "grid grid-cols-subgrid col-span-full",
+          "items-center border-b",
+        )}
+      >
+        <p className="text-muted-foreground text-sm">{emulator.name}</p>
+
+        <FormField
+          control={form.control}
+          name="executablePath"
+          render={({ field, fieldState: { isDirty } }) => (
+            <FormItem>
+              <div className="flex items-center">
+                <Button
+                  size="icon"
+                  className="p-2 h-min w-min"
+                  variant="secondary"
+                  onClick={async (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    try {
+                      const result = await open({
+                        title: "Select Emulator Executable",
+                        multiple: false,
+                        directory: false,
+                      });
+
+                      if (result) {
+                        field.onChange(result);
+                      }
+                    } catch (e) {
+                      console.error(e);
+                    }
+                  }}
+                >
+                  <FolderOpenIcon className="w-[1rem] h-[1rem]" />
+                </Button>
+
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value || ""}
+                    placeholder="Enter path to executable"
+                    className={cn(
+                      "border-none",
+                      !isDirty && "text-muted-foreground",
+                    )}
+                  />
+                </FormControl>
+              </div>
+            </FormItem>
+          )}
+        />
+
+        <Button
+          disabled={pending || !isDirty}
+          type="submit"
+          size="icon"
+          onClick={() => console.log(form.formState)}
+          className="p-2 w-min h-min"
+        >
+          {pending ? (
+            <LoaderCircleIcon className="w-[1rem] h-[1rem] animate-spin" />
+          ) : (
+            <SaveIcon className="w-[1rem] h-[1rem]" />
+          )}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/packages/client/web/src/components/modals/manage-profiles/index.tsx
+++ b/packages/client/web/src/components/modals/manage-profiles/index.tsx
@@ -57,7 +57,7 @@ export function ManageEmulatorProfilesModal() {
         ) : error ? (
           <></>
         ) : (
-          <ScrollArea type="auto" className="h-[65dvh] pr-4">
+          <ScrollArea type="auto">
             <Accordion type="multiple" className="w-full max-w-full">
               {emulators.map((emulator) => (
                 <ProfileList

--- a/packages/client/web/src/components/modals/setup/context.tsx
+++ b/packages/client/web/src/components/modals/setup/context.tsx
@@ -20,7 +20,7 @@ const SetupModalContext = createContext<
   | undefined
 >(undefined);
 
-// eslint-disable-next-line react-refresh/only-export-components -- we need to export this hook
+ 
 export function useSetupModal() {
   const context = useContext(SetupModalContext);
 

--- a/packages/client/web/src/components/modals/update-library/index.tsx
+++ b/packages/client/web/src/components/modals/update-library/index.tsx
@@ -41,7 +41,7 @@ export function UpdateLibraryModal() {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Update Library</DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="max-w-[65ch]">
             Starts the update process to populate platforms and games that have
             been added to the service&apos;s filesystem since the last update.
           </DialogDescription>

--- a/packages/client/web/src/components/modals/update-metadata/manual-tab.tsx
+++ b/packages/client/web/src/components/modals/update-metadata/manual-tab.tsx
@@ -21,7 +21,6 @@ import { useUpdateGameMetadata } from "@/mutations/useUpdateGameMetadata";
 import { Checkbox } from "../../ui/checkbox";
 import { useUpdateGames } from "@/mutations/useUpdateGames";
 import { useGameDetail } from "@/providers/game-details";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNavigate } from "@tanstack/react-router";
 
 type FormFieldRenderer = ({
@@ -137,14 +136,12 @@ export function ManualTab() {
       <div className="space-y-4">
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleUpdate)}>
-            <ScrollArea className={cn("h-[60dvh] pr-4 relative")}>
-              <div className="my-4 flex flex-col gap-4 pb-8">
-                {Object.entries(fields).map(([key, FormFieldRenderer]) => (
-                  <FormFieldRenderer form={form} key={key} />
-                ))}
-              </div>
-              <div className="absolute bottom-0 inset-x-0 h-8 bg-gradient-to-t from-background z-10" />
-            </ScrollArea>
+            <div className="my-4 flex flex-col gap-4 pb-8">
+              {Object.entries(fields).map(([key, FormFieldRenderer]) => (
+                <FormFieldRenderer form={form} key={key} />
+              ))}
+            </div>
+            <div className="absolute bottom-0 inset-x-0 h-8 bg-gradient-to-t from-background z-10" />
 
             <DialogFooter>
               <div className="flex items-center justify-between gap-6 w-full mt-4">

--- a/packages/client/web/src/components/ui/dialog.tsx
+++ b/packages/client/web/src/components/ui/dialog.tsx
@@ -71,7 +71,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed overflow-y-auto inset-0 z-40 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -85,29 +85,19 @@ const DialogContent = React.forwardRef<
     userCanClose?: boolean;
     handleScroll?: boolean;
   }
->(
-  (
-    { className, children, userCanClose = true, handleScroll = true, ...props },
-    ref,
-  ) => (
-    <DialogPortal>
-      <DialogOverlay />
-      <div className="fixed z-50 inset-0 grid place-items-center">
+>(({ className, children, userCanClose = true, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay>
+      <ScrollArea className="h-screen w-screen">
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            "relative [&_*]:ring-inset w-auto max-w-[65vw] max-h-[95dvh] grid gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+            "relative mx-auto my-12 [&_*]:ring-inset w-fit max-w-screen-lg flex flex-col gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
             className,
           )}
           {...props}
         >
-          {handleScroll ? (
-            <ScrollArea className="max-h-[90dvh] px-3 mt-2 overflow-x-visible">
-              {children}
-            </ScrollArea>
-          ) : (
-            children
-          )}
+          {children}
           {userCanClose ? (
             <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
               <X className="h-4 w-4" />
@@ -115,10 +105,10 @@ const DialogContent = React.forwardRef<
             </DialogPrimitive.Close>
           ) : null}
         </DialogPrimitive.Content>
-      </div>
-    </DialogPortal>
-  ),
-);
+      </ScrollArea>
+    </DialogOverlay>
+  </DialogPortal>
+));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({

--- a/packages/client/web/src/components/ui/input.tsx
+++ b/packages/client/web/src/components/ui/input.tsx
@@ -13,7 +13,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <input
         type={type}
-        className={cn(styles, className)}
+        className={cn(
+          styles,
+          className,
+          'aria-[invalid="true"]:ring-destructive-text aria-[invalid="true"]:ring-2',
+        )}
         ref={ref}
         {...props}
       />

--- a/packages/client/web/src/components/ui/tabs.tsx
+++ b/packages/client/web/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center rounded-md bg-white/10 p-1 text-muted-foreground",
       className,
     )}
     {...props}

--- a/packages/client/web/src/mutations/useCreateLocalEmulatorConfig.ts
+++ b/packages/client/web/src/mutations/useCreateLocalEmulatorConfig.ts
@@ -1,0 +1,23 @@
+import { CreateLocalEmulatorConfigsRequest } from "@/generated/retrom/services";
+import { useRetromClient } from "@/providers/retrom-client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useCreateLocalEmulatorConfigs() {
+  const queryClient = useQueryClient();
+  const retromClient = useRetromClient();
+
+  return useMutation({
+    mutationFn: (request: CreateLocalEmulatorConfigsRequest) =>
+      retromClient.emulatorClient.createLocalEmulatorConfigs(request),
+    mutationKey: ["create-local-emulator-configs", queryClient],
+    onError: (error) => {
+      console.error(error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          ["local-emulator-configs"].some((v) => query.queryKey.includes(v)),
+      });
+    },
+  });
+}

--- a/packages/client/web/src/mutations/useUpdateLocalEmulatorConfigs.ts
+++ b/packages/client/web/src/mutations/useUpdateLocalEmulatorConfigs.ts
@@ -1,0 +1,20 @@
+import { UpdateLocalEmulatorConfigsRequest } from "@/generated/retrom/services";
+import { useRetromClient } from "@/providers/retrom-client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useUpdateLocalEmulatorConfig() {
+  const queryClient = useQueryClient();
+  const retromClient = useRetromClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateLocalEmulatorConfigsRequest) =>
+      retromClient.emulatorClient.updateLocalEmulatorConfigs(request),
+    mutationKey: ["update-local-emulator-configs"],
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          ["local-emulator-configs"].some((v) => query.queryKey.includes(v)),
+      });
+    },
+  });
+}

--- a/packages/client/web/src/providers/config/index.tsx
+++ b/packages/client/web/src/providers/config/index.tsx
@@ -49,7 +49,7 @@ export function ConfigProvider(props: PropsWithChildren) {
   return <context.Provider value={configStore}>{children}</context.Provider>;
 }
 
-// eslint-disable-next-line react-refresh/only-export-components -- we need to export this hook
+ 
 export function useConfig() {
   const store = useContext(context);
 

--- a/packages/client/web/src/providers/retrom-client/index.tsx
+++ b/packages/client/web/src/providers/retrom-client/index.tsx
@@ -22,7 +22,7 @@ export function RetromClientProvider(props: PropsWithChildren) {
   return <context.Provider value={client}>{children}</context.Provider>;
 }
 
-// eslint-disable-next-line react-refresh/only-export-components -- we need to export this hook
+ 
 export function useRetromClient() {
   const client = useContext(context);
 

--- a/packages/client/web/src/queries/useEmulators.ts
+++ b/packages/client/web/src/queries/useEmulators.ts
@@ -2,7 +2,6 @@ import {
   GetEmulatorsRequest,
   GetEmulatorsResponse,
 } from "@/generated/retrom/services";
-import { useConfig } from "@/providers/config";
 import { useRetromClient } from "@/providers/retrom-client";
 import { useQuery } from "@tanstack/react-query";
 
@@ -16,21 +15,12 @@ export function useEmulators<T = GetEmulatorsResponse>(
   } = {},
 ) {
   const { request = {}, selectFn, enabled } = opts;
-  const configStore = useConfig();
-  const clientId = configStore((store) => store.config.clientInfo.id);
   const retromClient = useRetromClient();
 
   return useQuery({
-    queryKey: ["emulators", request, retromClient, clientId],
+    queryKey: ["emulators", request, retromClient],
     select: selectFn,
     enabled,
-    queryFn: async () => {
-      const res = await retromClient.emulatorClient.getEmulators(request);
-      res.emulators = res.emulators.filter(
-        (emulator) => emulator.clientId === clientId,
-      );
-
-      return res;
-    },
+    queryFn: () => retromClient.emulatorClient.getEmulators(request),
   });
 }

--- a/packages/client/web/src/queries/useLocalEmulatorConfigs.ts
+++ b/packages/client/web/src/queries/useLocalEmulatorConfigs.ts
@@ -1,0 +1,38 @@
+import {
+  GetLocalEmulatorConfigsRequest,
+  GetLocalEmulatorConfigsResponse,
+} from "@/generated/retrom/services";
+import { useConfig } from "@/providers/config";
+import { useRetromClient } from "@/providers/retrom-client";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+type SelectFn<S> = (data: GetLocalEmulatorConfigsResponse) => S;
+
+export function useLocalEmulatorConfigs<T = GetLocalEmulatorConfigsResponse>(
+  opts: {
+    request?: Partial<GetLocalEmulatorConfigsRequest>;
+    selectFn?: SelectFn<T>;
+    enabled?: boolean;
+  } = {},
+) {
+  const { request = {}, selectFn, enabled } = opts;
+  const configStore = useConfig();
+  const clientId = configStore((store) => store.config.clientInfo.id);
+  const retromClient = useRetromClient();
+
+  const req = useMemo(
+    () => ({
+      emulatorIds: request.emulatorIds ?? [],
+      clientId,
+    }),
+    [request.emulatorIds, clientId],
+  );
+
+  return useQuery({
+    queryKey: ["local-emulator-configs", req, retromClient, clientId],
+    select: selectFn,
+    enabled,
+    queryFn: () => retromClient.emulatorClient.getLocalEmulatorConfigs(req),
+  });
+}

--- a/packages/codegen/build.rs
+++ b/packages/codegen/build.rs
@@ -10,6 +10,13 @@ const DIESEL_ROW_DERIVES: [&str; 5] = [
     "AsChangeset",
 ];
 
+type ModelDefinitionParams = (
+    &'static str,
+    &'static str,
+    Option<&'static str>,
+    Vec<&'static str>,
+);
+
 // Derives that are used for structs representing new rows to be inserted into db
 const DIESEL_INSERTABLE_DERIVES: [&str; 1] = ["Insertable"];
 
@@ -52,7 +59,152 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .filter(|path| path.extension() == Some("proto".as_ref()))
         .collect();
 
-    tonic_build::configure()
+    let queryable_models: [ModelDefinitionParams; 13] = [
+        ("Platform", "platforms", None, vec![]),
+        ("Game", "games", None, vec![]),
+        (
+            "GameFile",
+            "game_files",
+            None,
+            vec!["Game, foreign_key = game_id"],
+        ),
+        (
+            "GameMetadata",
+            "game_metadata",
+            Some("game_id"),
+            vec!["Game, foreign_key = game_id"],
+        ),
+        (
+            "PlatformMetadata",
+            "platform_metadata",
+            Some("platform_id"),
+            vec!["Platform, foreign_key = platform_id"],
+        ),
+        ("Client", "clients", None, vec![]),
+        ("Emulator", "emulators", None, vec![]),
+        (
+            "EmulatorProfile",
+            "emulator_profiles",
+            None,
+            vec!["Emulator, foreign_key = emulator_id"],
+        ),
+        (
+            "DefaultEmulatorProfile",
+            "default_emulator_profiles",
+            Some("platform_id"),
+            vec![
+                "Platform, foreign_key = platform_id",
+                "Client, foreign_key = client_id",
+                "EmulatorProfile, foreign_key = emulator_profile_id",
+            ],
+        ),
+        ("GameGenre", "game_genres", None, vec![]),
+        (
+            "GameGenreMap",
+            "game_genre_maps",
+            Some("game_id, genre_id"),
+            vec![
+                "GameGenre, foreign_key = genre_id",
+                "Game, foreign_key = game_id",
+            ],
+        ),
+        (
+            "SimilarGameMap",
+            "similar_game_maps",
+            Some("game_id, similar_game_id"),
+            vec!["Game, foreign_key = game_id"],
+        ),
+        (
+            "LocalEmulatorConfig",
+            "local_emulator_configs",
+            None,
+            vec!["Emulator", "Client"],
+        ),
+    ];
+
+    let insertable_models: [ModelDefinitionParams; 13] = [
+        ("NewPlatform", "platforms", None, vec![]),
+        ("NewGame", "games", None, vec![]),
+        ("NewGameFile", "game_files", None, vec![]),
+        ("NewGameMetadata", "game_metadata", None, vec![]),
+        ("NewPlatformMetadata", "platform_metadata", None, vec![]),
+        ("NewClient", "clients", None, vec![]),
+        ("NewEmulator", "emulators", None, vec![]),
+        ("NewEmulatorProfile", "emulator_profiles", None, vec![]),
+        (
+            "NewDefaultEmulatorProfile",
+            "default_emulator_profiles",
+            None,
+            vec![],
+        ),
+        ("NewGameGenre", "game_genres", None, vec![]),
+        (
+            "NewGameGenreMap",
+            "game_genre_maps",
+            Some("game_id, genre_id"),
+            vec![],
+        ),
+        (
+            "NewSimilarGameMap",
+            "similar_game_maps",
+            Some("game_id, similar_game_id"),
+            vec![],
+        ),
+        (
+            "NewLocalEmulatorConfig",
+            "local_emulator_configs",
+            None,
+            vec![],
+        ),
+    ];
+
+    let updatable_models: [ModelDefinitionParams; 13] = [
+        ("UpdatedPlatform", "platforms", None, vec![]),
+        ("UpdatedGame", "games", None, vec![]),
+        ("UpdatedGameFile", "game_files", None, vec![]),
+        (
+            "UpdatedGameMetadata",
+            "game_metadata",
+            Some("game_id"),
+            vec![],
+        ),
+        (
+            "UpdatedPlatformMetadata",
+            "platform_metadata",
+            Some("platform_id"),
+            vec![],
+        ),
+        ("UpdatedClient", "clients", None, vec![]),
+        ("UpdatedEmulator", "emulators", None, vec![]),
+        ("UpdatedEmulatorProfile", "emulator_profiles", None, vec![]),
+        (
+            "UpdatedDefaultEmulatorProfile",
+            "default_emulator_profiles",
+            Some("platform_id"),
+            vec![],
+        ),
+        ("UpdatedGameGenre", "game_genres", None, vec![]),
+        (
+            "UpdatedGameGenreMap",
+            "game_genre_maps",
+            Some("game_id, genre_id"),
+            vec![],
+        ),
+        (
+            "UpdatedSimilarGameMap",
+            "similar_game_maps",
+            Some("game_id, similar_game_id"),
+            vec![],
+        ),
+        (
+            "UpdatedLocalEmulatorConfig",
+            "local_emulator_configs",
+            None,
+            vec!["Emulator", "Client"],
+        ),
+    ];
+
+    let mut build = tonic_build::configure()
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .extern_path(".google.protobuf.Timestamp", "crate::timestamp::Timestamp")
         .extern_path(".google.protobuf.Duration", "::prost_wkt_types::Duration")
@@ -60,270 +212,329 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .message_attribute(
             ".retrom",
             "#[serde(rename_all(serialize = \"camelCase\", deserialize = \"camelCase\"))]",
-        )
-        .type_attribute(
-            "retrom.Platform",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("platforms", None)
+        );
+    // .type_attribute(
+    //     "retrom.Platform",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("platforms", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewPlatform",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("platforms", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedPlatform",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("platforms", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.Game",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("games", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewGame",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("games", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedGame",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("games", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.GameFile",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_files", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewGameFile",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_files", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedGameFile",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_files", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.GameMetadata",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_metadata", "game_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewGameMetadata",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_metadata", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedGameMetadata",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_metadata", "game_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.PlatformMetadata",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("platform_metadata", "platform_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewPlatformMetadata",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("platform_metadata", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedPlatformMetadata",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("platform_metadata", "platform_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.Client",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("clients", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewClient",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("clients", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedClient",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("clients", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.Emulator",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("emulators", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewEmulator",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("emulators", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedEmulator",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("emulators", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.EmulatorProfile",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("emulator_profiles", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewEmulatorProfile",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("emulator_profiles", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedEmulatorProfile",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("emulator_profiles", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.DefaultEmulatorProfile",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("default_emulator_profiles", "platform_id, client_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewDefaultEmulatorProfile",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("default_emulator_profiles", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedDefaultEmulatorProfile",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("default_emulator_profiles", "platform_id, client_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.GameGenre",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_genres", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewGameGenre",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_genres", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedGameGenre",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_genres", None)
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.GameGenreMap",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},diesel::Associations,{other_derivations})]\n{}\n#[diesel(belongs_to(Game))]\n#[diesel(belongs_to())]",
+    //         get_diesel_macro("game_genre_maps", "game_id, genre_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewGameGenreMap",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_genre_maps", "game_id, genre_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedGameGenreMap",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("game_genre_maps", "game_id, genre_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.SimilarGameMap",
+    //     format!(
+    //         "#[derive({diesel_row_derivations},diesel::Associations,{other_derivations})]\n{}\n#[diesel(belongs_to(Game, foreign_key = game_id))]",
+    //         get_diesel_macro("similar_game_maps", "game_id, similar_game_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.NewSimilarGameMap",
+    //     format!(
+    //         "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("similar_game_maps", "game_id, similar_game_id".into())
+    //     ),
+    // )
+    // .type_attribute(
+    //     "retrom.UpdatedSimilarGameMap",
+    //     format!(
+    //         "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
+    //         get_diesel_macro("similar_game_maps", "game_id, similar_game_id".into())
+    //     ),
+    // );
+
+    for (model_name, table_name, primary_key, belongs_to) in queryable_models.into_iter() {
+        let derives = match belongs_to.len() {
+            0 => format!("#[derive({diesel_row_derivations},{other_derivations})]",),
+            _ => format!(
+                "#[derive({diesel_row_derivations},diesel::Associations,{other_derivations})]",
             ),
-        )
-        .type_attribute(
-            "retrom.NewPlatform",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("platforms", None)
+        };
+
+        let diesel_macro_clause = get_diesel_macro(table_name, primary_key, belongs_to);
+
+        build = build.type_attribute(
+            format!("retrom.{}", model_name),
+            format!("{derives}\n{diesel_macro_clause}",),
+        );
+    }
+
+    for (model_name, table_name, primary_key, belongs_to) in insertable_models.into_iter() {
+        let derives = match belongs_to.len() {
+            0 => format!("#[derive({diesel_insertable_derivations},{other_derivations})]",),
+            _ => format!(
+                "#[derive({diesel_insertable_derivations},diesel::Associations,{other_derivations})]",
             ),
-        )
-        .type_attribute(
-            "retrom.UpdatedPlatform",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("platforms", None)
+        };
+
+        let diesel_macro_clause = get_diesel_macro(table_name, primary_key, belongs_to);
+
+        build = build.type_attribute(
+            format!("retrom.{}", model_name),
+            format!("{derives}\n{diesel_macro_clause}",),
+        );
+    }
+
+    for (model_name, table_name, primary_key, belongs_to) in updatable_models.into_iter() {
+        let derives = match belongs_to.len() {
+            0 => format!("#[derive({diesel_update_derivations},{other_derivations})]",),
+            _ => format!(
+                "#[derive({diesel_update_derivations},diesel::Associations,{other_derivations})]",
             ),
-        )
-        .type_attribute(
-            "retrom.Game",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("games", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.NewGame",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("games", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedGame",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("games", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.GameFile",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_files", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.NewGameFile",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_files", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedGameFile",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_files", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.GameMetadata",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_metadata", "game_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.NewGameMetadata",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_metadata", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedGameMetadata",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_metadata", "game_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.PlatformMetadata",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("platform_metadata", "platform_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.NewPlatformMetadata",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("platform_metadata", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedPlatformMetadata",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("platform_metadata", "platform_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.Client", 
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("clients", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.NewClient",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("clients", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedClient", 
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("clients", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.Emulator",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("emulators", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.NewEmulator",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("emulators", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedEmulator",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("emulators", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.EmulatorProfile",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("emulator_profiles", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.NewEmulatorProfile",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("emulator_profiles", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedEmulatorProfile",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("emulator_profiles", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.DefaultEmulatorProfile",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("default_emulator_profiles", "platform_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.NewDefaultEmulatorProfile",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("default_emulator_profiles", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedDefaultEmulatorProfile",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("default_emulator_profiles", "platform_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.GameGenre",
-            format!(
-                "#[derive({diesel_row_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_genres", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.NewGameGenre",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_genres", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedGameGenre",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_genres", None)
-            ),
-        )
-        .type_attribute(
-            "retrom.GameGenreMap",
-            format!(
-                "#[derive({diesel_row_derivations},diesel::Associations,{other_derivations})]\n{}\n#[diesel(belongs_to(Game))]\n#[diesel(belongs_to(GameGenre, foreign_key = genre_id))]",
-                get_diesel_macro("game_genre_maps", "game_id, genre_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.NewGameGenreMap",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_genre_maps", "game_id, genre_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedGameGenreMap",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("game_genre_maps", "game_id, genre_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.SimilarGameMap",
-            format!(
-                "#[derive({diesel_row_derivations},diesel::Associations,{other_derivations})]\n{}\n#[diesel(belongs_to(Game, foreign_key = game_id))]",
-                get_diesel_macro("similar_game_maps", "game_id, similar_game_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.NewSimilarGameMap",
-            format!(
-                "#[derive({diesel_insertable_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("similar_game_maps", "game_id, similar_game_id".into())
-            ),
-        )
-        .type_attribute(
-            "retrom.UpdatedSimilarGameMap",
-            format!(
-                "#[derive({diesel_update_derivations},{other_derivations})]\n{}",
-                get_diesel_macro("similar_game_maps", "game_id, similar_game_id".into())
-            ),
-        )
+        };
+
+        let diesel_macro_clause = get_diesel_macro(table_name, primary_key, belongs_to);
+
+        build = build.type_attribute(
+            format!("retrom.{}", model_name),
+            format!("{derives}\n{diesel_macro_clause}",),
+        );
+    }
+
+    build
         .file_descriptor_set_path(out_dir.join("retrom_descriptor.bin"))
         .compile(&proto_paths, &["./protos/"])?;
 
     Ok(())
 }
 
-fn get_diesel_macro(table_name: &str, primary_key: Option<&str>) -> String {
+fn get_diesel_macro(table_name: &str, primary_key: Option<&str>, belongs_to: Vec<&str>) -> String {
     let primary_key_clause = match primary_key {
         Some(pk) => format!(", primary_key({pk})"),
         None => "".to_string(),
     };
 
-    format!("#[diesel(table_name = retrom_db::schema::{table_name}, check_for_backend(diesel::pg::Pg){primary_key_clause})]")
+    let belongs_to_clauses = belongs_to
+        .iter()
+        .map(|b| format!(", belongs_to({b})"))
+        .collect::<Vec<String>>()
+        .join("");
+
+    format!(
+        "#[diesel(table_name = retrom_db::schema::{table_name}, \
+        check_for_backend(diesel::pg::Pg){primary_key_clause}{belongs_to_clauses})]"
+    )
 }

--- a/packages/codegen/protos/retrom/models/emulators.proto
+++ b/packages/codegen/protos/retrom/models/emulators.proto
@@ -17,8 +17,6 @@ message Emulator {
   SaveStrategy save_strategy = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
-  int32 client_id = 7;
-  string executable_path = 8;
 }
 
 message NewEmulator {
@@ -27,8 +25,6 @@ message NewEmulator {
   SaveStrategy save_strategy = 3;
   optional google.protobuf.Timestamp created_at = 4;
   optional google.protobuf.Timestamp updated_at = 5;
-  int32 client_id = 6;
-  string executable_path = 7;
 }
 
 message UpdatedEmulator {
@@ -38,8 +34,6 @@ message UpdatedEmulator {
   optional SaveStrategy save_strategy = 4;
   optional google.protobuf.Timestamp created_at = 5;
   optional google.protobuf.Timestamp updated_at = 6;
-  optional int32 client_id = 7;
-  optional string executable_path = 8;
 }
 
 message EmulatorProfile {
@@ -93,4 +87,33 @@ message UpdatedDefaultEmulatorProfile {
   optional google.protobuf.Timestamp created_at = 3;
   optional google.protobuf.Timestamp updated_at = 4;
   optional int32 client_id = 5;
+}
+
+message LocalEmulatorConfig {
+  int32 id = 1;
+  int32 emulator_id = 2;
+  int32 client_id = 3;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp updated_at = 5;
+  string executable_path = 6;
+  optional string nickname = 7;
+}
+
+message NewLocalEmulatorConfig {
+  int32 emulator_id = 1;
+  int32 client_id = 2;
+  optional google.protobuf.Timestamp created_at = 3;
+  optional google.protobuf.Timestamp updated_at = 4;
+  string executable_path = 5;
+  optional string nickname = 6;
+}
+
+message UpdatedLocalEmulatorConfig {
+  int32 id = 1;
+  optional int32 emulator_id = 2;
+  optional int32 client_id = 3;
+  optional google.protobuf.Timestamp created_at = 4;
+  optional google.protobuf.Timestamp updated_at = 5;
+  optional string executable_path = 6;
+  optional string nickname = 7;
 }

--- a/packages/codegen/protos/retrom/models/game-files.proto
+++ b/packages/codegen/protos/retrom/models/game-files.proto
@@ -5,6 +5,8 @@ package retrom;
 import "google/protobuf/timestamp.proto";
 
 message GameFile {
+  reserved 2, 5;
+
   int32 id = 1;
   int64 byte_size = 3;
   string path = 4;

--- a/packages/codegen/protos/retrom/services.proto
+++ b/packages/codegen/protos/retrom/services.proto
@@ -70,6 +70,11 @@ service EmulatorService {
   rpc GetDefaultEmulatorProfiles(GetDefaultEmulatorProfilesRequest) returns (GetDefaultEmulatorProfilesResponse);
   rpc UpdateDefaultEmulatorProfiles(UpdateDefaultEmulatorProfilesRequest) returns (UpdateDefaultEmulatorProfilesResponse);
   rpc DeleteDefaultEmulatorProfiles(DeleteDefaultEmulatorProfilesRequest) returns (DeleteDefaultEmulatorProfilesResponse);
+
+  rpc CreateLocalEmulatorConfigs(CreateLocalEmulatorConfigsRequest) returns (CreateLocalEmulatorConfigsResponse);
+  rpc GetLocalEmulatorConfigs(GetLocalEmulatorConfigsRequest) returns (GetLocalEmulatorConfigsResponse);
+  rpc UpdateLocalEmulatorConfigs(UpdateLocalEmulatorConfigsRequest) returns (UpdateLocalEmulatorConfigsResponse);
+  rpc DeleteLocalEmulatorConfigs(DeleteLocalEmulatorConfigsRequest) returns (DeleteLocalEmulatorConfigsResponse);
 }
 
 service JobService {
@@ -401,4 +406,37 @@ message GetJobSubscriptionRequest {
 
 message GetJobSubscriptionResponse {
   JobProgress job = 1;
+}
+
+message CreateLocalEmulatorConfigsRequest {
+  repeated NewLocalEmulatorConfig configs = 1;
+}
+
+message CreateLocalEmulatorConfigsResponse {
+  repeated LocalEmulatorConfig configs_created = 1;
+}
+
+message GetLocalEmulatorConfigsRequest {
+  repeated int32 emulator_ids = 1;
+  int32 client_id = 2;
+}
+
+message GetLocalEmulatorConfigsResponse {
+  repeated LocalEmulatorConfig configs = 1;
+}
+
+message UpdateLocalEmulatorConfigsRequest {
+  repeated UpdatedLocalEmulatorConfig configs = 1;
+}
+
+message UpdateLocalEmulatorConfigsResponse {
+  repeated LocalEmulatorConfig configs_updated = 1;
+}
+
+message DeleteLocalEmulatorConfigsRequest {
+  repeated int32 ids = 1;
+}
+
+message DeleteLocalEmulatorConfigsResponse {
+  repeated LocalEmulatorConfig configs_deleted = 1;
 }

--- a/packages/db/migrations/2024-08-19-040945_model_deletion_and_mutations/down.sql
+++ b/packages/db/migrations/2024-08-19-040945_model_deletion_and_mutations/down.sql
@@ -1,11 +1,20 @@
-ALTER TABLE "platforms" DROP COLUMN "deleted_at";
-ALTER TABLE "platforms" DROP COLUMN "is_deleted";
+ALTER TABLE "platforms"
+DROP COLUMN "deleted_at";
 
-ALTER TABLE "games" DROP COLUMN "deleted_at";
-ALTER TABLE "games" DROP COLUMN "is_deleted";
-ALTER TABLE "games" DROP COLUMN "default_file_id";
+ALTER TABLE "platforms"
+DROP COLUMN "is_deleted";
 
-ALTER TABLE "game_files" DROP COLUMN "deleted_at";
-ALTER TABLE "game_files" DROP COLUMN "is_deleted";
-ALTER TABLE "games" DROP COLUMN "default_file_id";
+ALTER TABLE "games"
+DROP COLUMN "deleted_at";
 
+ALTER TABLE "games"
+DROP COLUMN "is_deleted";
+
+ALTER TABLE "games"
+DROP COLUMN "default_file_id";
+
+ALTER TABLE "game_files"
+DROP COLUMN "deleted_at";
+
+ALTER TABLE "game_files"
+DROP COLUMN "is_deleted";

--- a/packages/db/migrations/2024-10-17-012359_local-emulator-configs/down.sql
+++ b/packages/db/migrations/2024-10-17-012359_local-emulator-configs/down.sql
@@ -1,0 +1,22 @@
+-- put the removed columns back on emulators table
+ALTER TABLE emulators
+ADD COLUMN executable_path TEXT NOT NULL;
+
+ALTER TABLE emulators
+ADD COLUMN client_id INTEGER NOT NULL;
+
+ALTER TABLE emulators ADD CONSTRAINT fk_client_id FOREIGN KEY (client_id) REFERENCES clients (id) ON DELETE CASCADE;
+
+-- Migrate data back to the emulator table
+UPDATE emulators
+SET
+  executable_path = lec.executable_path,
+  client_id = lec.client_id
+FROM
+  local_emulator_configs lec
+WHERE
+  emulators.id = lec.emulator_id
+  AND lec.executable_path IS NOT NULL;
+
+-- DROP TABLE "local_emulator_configs";
+DROP TABLE "local_emulator_configs";

--- a/packages/db/migrations/2024-10-17-012359_local-emulator-configs/up.sql
+++ b/packages/db/migrations/2024-10-17-012359_local-emulator-configs/up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "local_emulator_configs" (
+  "id" INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  "emulator_id" INTEGER NOT NULL,
+  "client_id" INTEGER NOT NULL,
+  "created_at" TIMESTAMP
+  WITH
+    TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP
+  WITH
+    TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "executable_path" TEXT NOT NULL,
+    "nickname" TEXT DEFAULT NULL,
+    CONSTRAINT "uq_local_emulator_configs_emulator_id_client_id" UNIQUE ("emulator_id", "client_id"),
+    CONSTRAINT "fk_local_emulator_configs_emulators" FOREIGN KEY ("emulator_id") REFERENCES "emulators" ("id") ON DELETE CASCADE,
+    CONSTRAINT "fk_local_emulator_configs_clients" FOREIGN KEY ("client_id") REFERENCES "clients" ("id") ON DELETE CASCADE
+);
+
+-- move the executable_path column from emulators table to local_emulator_configs table
+INSERT INTO
+  "local_emulator_configs" (emulator_id, client_id, executable_path)
+SELECT
+  id,
+  client_id,
+  executable_path
+FROM
+  emulators ON CONFLICT DO NOTHING;
+
+-- drop the columns from emulators table
+ALTER TABLE emulators
+DROP COLUMN executable_path;
+
+ALTER TABLE emulators
+DROP COLUMN client_id CASCADE;

--- a/packages/db/src/schema.patch
+++ b/packages/db/src/schema.patch
@@ -1,8 +1,8 @@
 diff --git a/packages/db/src/schema.rs b/packages/db/src/schema.rs
-index 800f090..24dd9b5 100644
+index 9dc9e73..2e87a18 100644
 --- a/packages/db/src/schema.rs
 +++ b/packages/db/src/schema.rs
-@@ -21,23 +21,23 @@ diesel::table! {
+@@ -21,21 +21,21 @@ diesel::table! {
  
  diesel::table! {
      emulator_profiles (id) {
@@ -27,9 +27,7 @@ index 800f090..24dd9b5 100644
          save_strategy -> Int4,
          created_at -> Nullable<Timestamptz>,
          updated_at -> Nullable<Timestamptz>,
-         client_id -> Int4,
-         executable_path -> Text,
-@@ -82,16 +82,16 @@ diesel::table! {
+@@ -84,16 +84,16 @@ diesel::table! {
          cover_url -> Nullable<Text>,
          background_url -> Nullable<Text>,
          icon_url -> Nullable<Text>,

--- a/packages/db/src/schema.rs
+++ b/packages/db/src/schema.rs
@@ -39,8 +39,6 @@ diesel::table! {
         save_strategy -> Int4,
         created_at -> Nullable<Timestamptz>,
         updated_at -> Nullable<Timestamptz>,
-        client_id -> Int4,
-        executable_path -> Text,
     }
 }
 
@@ -112,6 +110,18 @@ diesel::table! {
 }
 
 diesel::table! {
+    local_emulator_configs (id) {
+        id -> Int4,
+        emulator_id -> Int4,
+        client_id -> Int4,
+        created_at -> Nullable<Timestamptz>,
+        updated_at -> Nullable<Timestamptz>,
+        executable_path -> Text,
+        nickname -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
     platform_metadata (platform_id) {
         platform_id -> Int4,
         name -> Nullable<Text>,
@@ -148,11 +158,12 @@ diesel::joinable!(default_emulator_profiles -> clients (client_id));
 diesel::joinable!(default_emulator_profiles -> emulator_profiles (emulator_profile_id));
 diesel::joinable!(default_emulator_profiles -> platforms (platform_id));
 diesel::joinable!(emulator_profiles -> emulators (emulator_id));
-diesel::joinable!(emulators -> clients (client_id));
 diesel::joinable!(game_genre_maps -> game_genres (genre_id));
 diesel::joinable!(game_genre_maps -> games (game_id));
 diesel::joinable!(game_metadata -> games (game_id));
 diesel::joinable!(games -> platforms (platform_id));
+diesel::joinable!(local_emulator_configs -> clients (client_id));
+diesel::joinable!(local_emulator_configs -> emulators (emulator_id));
 diesel::joinable!(platform_metadata -> platforms (platform_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -165,6 +176,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     game_genres,
     game_metadata,
     games,
+    local_emulator_configs,
     platform_metadata,
     platforms,
     similar_game_maps,


### PR DESCRIPTION
Emulators are no longer scoped to a single client. Any per-client configuration is now distinct from the emulators -- and, by extension, their profiles -- themselves. This means that profiles can now be used across clients!

BREAKING CHANGE: Emulator profiles are now shared across clients. A best effort has been made to migrate existing profiles to the new shared system, but some manual intervention/clean up may be required.