### PR TITLE
fix: sub-directories in game files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_zip"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
+dependencies = [
+ "async-compression",
+ "chrono",
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,10 +661,8 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -4170,6 +4184,7 @@ dependencies = [
 name = "retrom-service"
 version = "0.3.0"
 dependencies = [
+ "async_zip",
  "bigdecimal",
  "bytes",
  "config",
@@ -4208,8 +4223,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "walkdir",
  "warp",
- "zipit",
 ]
 
 [[package]]
@@ -7024,17 +7039,6 @@ dependencies = [
  "indexmap 2.5.0",
  "memchr",
  "thiserror",
-]
-
-[[package]]
-name = "zipit"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5715147b4b196369cbe37539dfc2f200c48195d4f20113e013950f381976a9"
-dependencies = [
- "chrono",
- "crc32fast",
- "tokio",
 ]
 
 [[package]]

--- a/packages/client/web/src/components/modals/check-for-update/index.tsx
+++ b/packages/client/web/src/components/modals/check-for-update/index.tsx
@@ -25,6 +25,7 @@ import { Route as RootRoute } from "@/routes/__root";
 import { useNavigate } from "@tanstack/react-router";
 import { Version } from "@/generated/retrom/server/server-info";
 import { Update } from "@tauri-apps/plugin-updater";
+import { Separator } from "@/components/ui/separator";
 
 type Progress = {
   downloaded: number;
@@ -148,10 +149,11 @@ function InnerContent(props: { clientVersion: Version; update?: Update }) {
     newVersion && update ? (
       <>
         <h3>
-          A new version of Retrom is available.{" "}
+          A new version of Retrom is available:{" "}
           <Code>{`${versionToString(clientVersion)} -> ${versionToString(newVersion)}`}</Code>
         </h3>
 
+        <Separator />
         <Changelog update={update} />
       </>
     ) : (
@@ -165,13 +167,17 @@ function InnerContent(props: { clientVersion: Version; update?: Update }) {
       <Content />
 
       {breakingChange ? (
-        <div className="flex gap-2 my-2">
-          <AlertCircle className="text-destructive-text" />
-          <p className="text-muted-fo">
-            This is a breaking change. Please ensure your server is also
-            up-to-date once you update the client or you will encounter issues.
-          </p>
-        </div>
+        <>
+          <Separator />
+          <div className="flex gap-2 my-2">
+            <AlertCircle className="text-destructive-text" />
+            <p>
+              This is a breaking change. Please ensure your server is also
+              up-to-date once you update the client or you will encounter
+              issues.
+            </p>
+          </div>
+        </>
       ) : (
         <></>
       )}

--- a/packages/client/web/src/components/modals/delete-game/index.tsx
+++ b/packages/client/web/src/components/modals/delete-game/index.tsx
@@ -23,6 +23,7 @@ export function DeleteGameModal() {
   const { toast } = useToast();
   const name = metadata?.name || getFileStub(game.path);
   const [deleteFromDisk, setDeleteFromDisk] = useState(false);
+  const [blacklistEntries, setBlacklistEntries] = useState(false);
   const { deleteGameModal } = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 
@@ -30,7 +31,11 @@ export function DeleteGameModal() {
 
   const handleDelete = useCallback(async () => {
     try {
-      const res = await deleteGame({ ids: [game.id], deleteFromDisk });
+      const res = await deleteGame({
+        ids: [game.id],
+        deleteFromDisk,
+        blacklistEntries,
+      });
 
       if (!res.gamesDeleted.length) {
         throw new Error("Failed to delete game");
@@ -40,7 +45,7 @@ export function DeleteGameModal() {
         title: "Failed to delete game",
       });
     }
-  }, [deleteGame, game.id, deleteFromDisk, toast]);
+  }, [deleteGame, game.id, deleteFromDisk, blacklistEntries, toast]);
 
   return (
     <Dialog
@@ -67,43 +72,60 @@ export function DeleteGameModal() {
           is, but Retrom will ignore the game&apos;s directory moving forward.
         </p>
 
+        <div className="flex flex-col gap-4">
+          <div className="flex items-top gap-2">
+            <Checkbox
+              id="delete-from-disk"
+              checked={deleteFromDisk}
+              onCheckedChange={(event) => setDeleteFromDisk(!!event)}
+            />
+
+            <div className="grid gap-1 5 leading-none">
+              <label htmlFor="delete-from-disk">Delete from disk</label>
+
+              <p className="text-sm text-muted-foreground">
+                This will alter the the file system
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-top gap-2">
+            <Checkbox
+              id="blacklist-entries"
+              checked={blacklistEntries}
+              onCheckedChange={(event) => setBlacklistEntries(!!event)}
+            />
+
+            <div className="grid gap-1 5 leading-none">
+              <label htmlFor="blacklist-entries">Blacklist entries</label>
+
+              <p className="text-sm text-muted-foreground max-w-[45ch]">
+                Enabling this will prevent the game and its files from being
+                re-imported in any future library scans
+              </p>
+            </div>
+          </div>
+        </div>
+
         <DialogFooter>
-          <div className="flex items-center justify-between gap-6 w-full">
-            <div className="flex items-top gap-2">
-              <Checkbox
-                id="delete-from-disk"
-                checked={deleteFromDisk}
-                onCheckedChange={(event) => setDeleteFromDisk(!!event)}
+          <div className="flex gap-2">
+            <DialogClose asChild>
+              <Button>Cancel</Button>
+            </DialogClose>
+
+            <Button
+              className="relative"
+              variant="destructive"
+              onClick={handleDelete}
+            >
+              <LoaderCircleIcon
+                className={cn(
+                  "animate-spin absolute",
+                  !isPending && "opacity-0",
+                )}
               />
-
-              <div className="grid gap-1 5 leading-none">
-                <label htmlFor="delete-from-disk">Delete from disk</label>
-
-                <p className="text-sm text-muted-foreground">
-                  This will alter the the file system
-                </p>
-              </div>
-            </div>
-
-            <div className="flex gap-2">
-              <DialogClose asChild>
-                <Button>Cancel</Button>
-              </DialogClose>
-
-              <Button
-                className="relative"
-                variant="destructive"
-                onClick={handleDelete}
-              >
-                <LoaderCircleIcon
-                  className={cn(
-                    "animate-spin absolute",
-                    !isPending && "opacity-0",
-                  )}
-                />
-                <p className={cn(isPending && "opacity-0")}>Delete</p>
-              </Button>
-            </div>
+              <p className={cn(isPending && "opacity-0")}>Delete</p>
+            </Button>
           </div>
         </DialogFooter>
       </DialogContent>

--- a/packages/client/web/src/lib/version-utils.module.scss
+++ b/packages/client/web/src/lib/version-utils.module.scss
@@ -29,20 +29,19 @@
   h4,
   h5,
   h6 {
-    @apply font-black mb-2;
+    @apply font-black text-2xl mb-2 uppercase text-muted-foreground/50;
   }
 
   ul {
-    list-style: disc;
-    list-style-position: inside;
+    list-style: none;
 
     li {
-      *:first-child {
-        @apply font-bold mb-1;
+      > *:first-child {
+        @apply font-bold mb-1 relative w-fit;
       }
 
-      *:not(:first-child) {
-        @apply pl-4;
+      > *:not(:first-child) {
+        @apply text-sm;
       }
     }
   }

--- a/packages/client/web/src/lib/version-utils.tsx
+++ b/packages/client/web/src/lib/version-utils.tsx
@@ -66,7 +66,7 @@ export function Changelog(props: { update: Update }) {
 
   return (
     <div className="py-2">
-      <ScrollArea className="h-full max-h-[65dvh] p-2 border bg-muted rounded">
+      <ScrollArea className="h-full max-h-[65dvh] rounded">
         {body ? (
           <Markdown className={classes.markdown}>{body}</Markdown>
         ) : (

--- a/packages/client/web/src/routes/games/$gameId/-components/game-files.tsx
+++ b/packages/client/web/src/routes/games/$gameId/-components/game-files.tsx
@@ -203,7 +203,7 @@ export function GameFiles() {
                     <div className="flex items-center">
                       <span className="overflow-ellipsis overflow-hidden relative">
                         <span className="whitespace-nowrap">
-                          {getFileName(file.path)}
+                          {file.path.replace(game.path + "/", "")}
                         </span>
                       </span>
                       {file.id === game.defaultFileId ? (

--- a/packages/client/web/src/routes/games/$gameId/-components/game-files.tsx
+++ b/packages/client/web/src/routes/games/$gameId/-components/game-files.tsx
@@ -48,6 +48,7 @@ export function GameFiles() {
     useUpdateGameFiles();
 
   const [deleteFromDisk, setDeleteFromDisk] = useState(false);
+  const [blacklistEntries, setBlacklistEntries] = useState(false);
   const [selectedFile, setSelectedFile] = useState("");
   const [renameValue, setRenameValue] = useState("");
 
@@ -61,6 +62,7 @@ export function GameFiles() {
     try {
       const res = await deleteGameFiles({
         ids: [file.id],
+        blacklistEntries,
         deleteFromDisk,
       });
 
@@ -82,7 +84,14 @@ export function GameFiles() {
         variant: "destructive",
       });
     }
-  }, [deleteGameFiles, toast, selectedFile, gameFiles, deleteFromDisk]);
+  }, [
+    deleteGameFiles,
+    toast,
+    selectedFile,
+    gameFiles,
+    deleteFromDisk,
+    blacklistEntries,
+  ]);
 
   const handleMakeDefault = useCallback(async () => {
     if (!selectedFile) return;
@@ -224,7 +233,7 @@ export function GameFiles() {
               </Button>
             </DropdownMenuTrigger>
 
-            <DropdownMenuContent>
+            <DropdownMenuContent className="z-[10]">
               <DropdownMenuGroup>
                 <DropdownMenuItem onClick={handleMakeDefault}>
                   Set as default
@@ -312,41 +321,62 @@ export function GameFiles() {
                       the file moving forward.
                     </p>
 
+                    <div className="flex flex-col gap-4">
+                      <div className="flex items-top gap-2">
+                        <Checkbox
+                          id="delete-from-disk"
+                          checked={deleteFromDisk}
+                          onCheckedChange={(event) =>
+                            setDeleteFromDisk(!!event)
+                          }
+                        />
+
+                        <div className="grid gap-1 5 leading-none">
+                          <label htmlFor="delete-from-disk">
+                            Delete from disk
+                          </label>
+
+                          <p className="text-sm text-muted-foreground">
+                            This will alter the file system
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="flex items-top gap-2">
+                        <Checkbox
+                          id="blacklist-entries"
+                          checked={blacklistEntries}
+                          onCheckedChange={(event) =>
+                            setBlacklistEntries(!!event)
+                          }
+                        />
+
+                        <div className="grid gap-1 5 leading-none">
+                          <label htmlFor="blacklist-entries">
+                            Blacklist entry
+                          </label>
+
+                          <p className="text-sm text-muted-foreground max-w-[45ch]">
+                            Enabling this will prevent the file from being
+                            re-imported in any future library scans
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
                     <DialogFooter>
-                      <div className="flex items-center justify-between gap-6 w-full">
-                        <div className="flex items-top gap-2">
-                          <Checkbox
-                            id="delete-from-disk"
-                            checked={deleteFromDisk}
-                            onCheckedChange={(event) =>
-                              setDeleteFromDisk(!!event)
-                            }
-                          />
+                      <div className="flex gap-2">
+                        <DialogClose asChild>
+                          <Button disabled={pending}>Cancel</Button>
+                        </DialogClose>
 
-                          <div className="grid gap-1 5 leading-none">
-                            <label htmlFor="delete-from-disk">
-                              Delete from disk
-                            </label>
-
-                            <p className="text-sm text-muted-foreground">
-                              This will alter the file system
-                            </p>
-                          </div>
-                        </div>
-
-                        <div className="flex gap-2">
-                          <DialogClose asChild>
-                            <Button disabled={pending}>Cancel</Button>
-                          </DialogClose>
-
-                          <Button
-                            onClick={handleDelete}
-                            variant="destructive"
-                            disabled={pending}
-                          >
-                            Delete
-                          </Button>
-                        </div>
+                        <Button
+                          onClick={handleDelete}
+                          variant="destructive"
+                          disabled={pending}
+                        >
+                          Delete
+                        </Button>
                       </div>
                     </DialogFooter>
                   </DialogContent>

--- a/packages/codegen/protos/retrom/services.proto
+++ b/packages/codegen/protos/retrom/services.proto
@@ -217,6 +217,7 @@ message DeleteLibraryResponse {}
 message DeletePlatformsRequest {
   repeated int32 ids = 1;
   bool delete_from_disk = 2;
+  bool blacklist_entries = 3;
 }
 
 message DeletePlatformsResponse {
@@ -234,6 +235,7 @@ message UpdatePlatformsResponse {
 message DeleteGamesRequest {
   repeated int32 ids = 1;
   bool delete_from_disk = 2;
+  bool blacklist_entries = 3;
 }
 
 message DeleteGamesResponse {
@@ -380,6 +382,7 @@ message DeleteDefaultEmulatorProfilesResponse {
 message DeleteGameFilesRequest {
   repeated int32 ids = 1;
   bool delete_from_disk = 2;
+  bool blacklist_entries = 3;
 }
 
 message DeleteGameFilesResponse {

--- a/packages/service/Cargo.toml
+++ b/packages/service/Cargo.toml
@@ -40,7 +40,6 @@ http-body = "0.4"
 http = "0.2"
 warp = "0.3.7"
 tokio-util = { workspace = true }
-zipit = { version = "0.4.0", features = ["tokio-async-io", "chrono-datetime"] }
 tokio-retry = { workspace = true }
 futures-util = "0.3.30"
 tokio-stream = { workspace = true }
@@ -48,3 +47,5 @@ thiserror = { workspace = true }
 sanitize-filename = { workspace = true }
 uuid = { version = "1.10.0", features = ["v4"] }
 config = { version = "0.14.0", features = ["json5"] }
+async_zip = { version = "0.0.17", features = ["full"] }
+walkdir = "2.5.0"

--- a/packages/service/src/rest/game.rs
+++ b/packages/service/src/rest/game.rs
@@ -1,18 +1,23 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use async_zip::{tokio::write::ZipFileWriter, Compression, ZipEntryBuilder};
 use diesel::associations::HasTable;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use futures::AsyncWriteExt;
 use http::header;
 use retrom_codegen::retrom;
-use retrom_db::{schema, Pool};
-use tokio_util::io::ReaderStream;
+use retrom_db::Pool;
+use tokio::io::AsyncReadExt;
+use tokio_util::{compat::FuturesAsyncWriteCompatExt, io::ReaderStream};
+use tracing::{debug, instrument, warn};
+use walkdir::WalkDir;
 use warp::{filters::BoxedFilter, Filter};
-use zipit::{archive_size, FileDateTime};
 
 use super::with_db_pool;
 
+#[instrument(skip_all)]
 pub fn get_game_files(pool: Arc<Pool>) -> BoxedFilter<(impl warp::Reply,)> {
     warp::path!("game" / i32)
         .and(warp::get())
@@ -46,57 +51,57 @@ pub fn get_game_files(pool: Arc<Pool>) -> BoxedFilter<(impl warp::Reply,)> {
                     .to_string(),
             };
 
-            let files: Vec<retrom::GameFile> = match retrom::GameFile::table()
-                .filter(schema::game_files::game_id.eq(game_id))
-                .load(&mut conn)
-                .await
-            {
-                Ok(files) => files,
-                Err(_) => return Err(warp::reject::not_found()),
-            };
-
-            let file_paths: Vec<PathBuf> = files
-                .into_iter()
-                .map(|file| PathBuf::from(file.path))
-                .collect();
-
-            let file_descriptors: Vec<(&str, usize)> = file_paths
-                .iter()
-                .map(|path| {
-                    let file_name = path.file_name().unwrap().to_str().unwrap_or("unknown");
-                    let file_size = path.metadata().unwrap().len() as usize;
-                    (file_name, file_size)
-                })
-                .collect();
-
-            let content_length = archive_size(file_descriptors);
-
             let (w, r) = tokio::io::duplex(4096);
             tokio::spawn(async move {
-                let mut archive = zipit::Archive::new(w);
+                let mut writer = ZipFileWriter::with_tokio(w);
+                let walkdir = WalkDir::new(game_path.clone());
+                let it = walkdir.into_iter().filter_map(|entry| match entry {
+                    Ok(entry) => match entry.path().is_file() {
+                        true => Some(entry),
+                        false => None,
+                    },
+                    Err(e) => {
+                        warn!("Failed to walk directory: {:?}", e);
+                        None
+                    }
+                });
 
-                for path in file_paths.iter() {
-                    let file_name = path.file_name().unwrap().to_str().unwrap_or("unknown");
-                    let mut file = tokio::fs::File::open(path).await.unwrap();
-                    match archive
-                        .append(file_name.to_string(), FileDateTime::now(), &mut file)
-                        .await
-                    {
-                        Ok(_) => (),
+                let src_dir = match game_path.clone().is_dir() {
+                    true => game_path.clone(),
+                    false => game_path.clone().parent().unwrap().to_path_buf(),
+                };
+
+                for entry in it {
+                    let path = entry.path();
+
+                    let file_name = path.strip_prefix(&src_dir).unwrap().to_str().unwrap();
+                    let mut file = match tokio::fs::File::open(path).await {
+                        Ok(file) => file,
                         Err(e) => {
-                            let msg = "Failed to append file to archive,".to_string()
-                                + "was the download interrupted?";
-
-                            tracing::error!("{msg}: {:?}", e);
-                            return;
+                            let msg = "Failed to open file, skipping".to_string();
+                            tracing::warn!("{msg}: {:?}", e);
+                            continue;
                         }
                     };
+
+                    let entry = ZipEntryBuilder::new(file_name.into(), Compression::Deflate);
+                    let stream_writer = writer.write_entry_stream(entry).await.unwrap();
+
+                    let mut stream_copy = stream_writer.compat_write();
+                    if let Err(e) = tokio::io::copy(&mut file, &mut stream_copy).await {
+                        let msg = "Failed to append file to archive,".to_string()
+                            + "was the download interrupted?";
+                        tracing::error!("{msg}: {:?}", e);
+                    }
+
+                    if let Err(e) = stream_copy.into_inner().close().await {
+                        let msg = "Failed to close file entry".to_string();
+                        tracing::error!("{msg}: {:?}", e);
+                        return;
+                    }
                 }
 
-                archive
-                    .finalize()
-                    .await
-                    .expect("Failed to finalize archive");
+                writer.close().await.unwrap();
             });
 
             let body = hyper::Body::wrap_stream(ReaderStream::new(r));
@@ -104,10 +109,6 @@ pub fn get_game_files(pool: Arc<Pool>) -> BoxedFilter<(impl warp::Reply,)> {
             let mut response = warp::reply::Response::new(body);
             let headers = response.headers_mut();
             headers.insert(header::CONTENT_TYPE, "application/zip".parse().unwrap());
-            headers.insert(
-                header::CONTENT_LENGTH,
-                content_length.to_string().parse().unwrap(),
-            );
 
             headers.insert(
                 header::CONTENT_DISPOSITION,

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -18,8 +18,8 @@ git_tag_name = "retrom-v{{ version }}"
 
 [changelog]
 commit_parsers = [
-  { message = "^feat", group = "added" },
-  { message = "^fix", group = "fixed" },
+  { message = "^feat", group = "New" },
+  { message = "^fix", group = "Fixes" },
 ]
 body = """
 ## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}


### PR DESCRIPTION
Any sub-directories in a MultiFileGame's directory is now properly
scanned and added to the game's file list. Installing such games from
the desktop client now works as expected, as does downloading them from
the web client.

NOTE: You may need to remove affected games and re-scan your library to
resolve any issues with existing games.