### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.2...retrom-v0.4.3) - 2024-11-19
+
+### Fixes
+- UI Tweaks
+
+    Fullscreen mode menus now work properly on smaller screen sizes.
+    Navigation via gamepad/hotkeys in fullscreen mode is now more intuitive.
+    Fullscreen mode now sorts platforms alphabetically.
+
+
+
+
 ## [0.4.2](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.1...retrom-v0.4.2) - 2024-11-17
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "diesel",
  "prost",
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,12 +34,12 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.4.2" }
-retrom-client = { path = "./packages/client", version = "^0.4.2" }
-retrom-service = { path = "./packages/service", version = "^0.4.2" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.4.2" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.2" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.2" }
+retrom-db = { path = "./packages/db", version = "^0.4.3" }
+retrom-client = { path = "./packages/client", version = "^0.4.3" }
+retrom-service = { path = "./packages/service", version = "^0.4.3" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.4.3" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.3" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.3" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.4.2 -> 0.4.3
* `retrom-codegen`: 0.4.2 -> 0.4.3
* `retrom-db`: 0.4.2 -> 0.4.3
* `retrom-plugin-installer`: 0.4.2 -> 0.4.3
* `retrom-plugin-launcher`: 0.4.2 -> 0.4.3
* `retrom-service`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.4.3](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.2...retrom-v0.4.3) - 2024-11-19

### Fixes
- UI Tweaks

    Fullscreen mode menus now work properly on smaller screen sizes.
    Navigation via gamepad/hotkeys in fullscreen mode is now more intuitive.
    Fullscreen mode now sorts platforms alphabetically.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).