### PR TITLE
retrom-v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.5](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.4...retrom-v0.4.5) - 2024-11-22
+
+### Fixes
+- don't show empty platforms in fullscreen mode
+
+    resolves [#182](https://github.com/JMBeresford/retrom/pull/182)
+
+
+
+- EGL Bad Parameter error on some devices
+
+
 ## [0.4.4](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.3...retrom-v0.4.4) - 2024-11-19
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "diesel",
  "prost",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "hyper 0.14.30",
  "hyper-rustls 0.25.0",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,13 +34,13 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.4.4" }
-retrom-client = { path = "./packages/client", version = "^0.4.4" }
-retrom-service = { path = "./packages/service", version = "^0.4.4" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.4.4" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.4" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.4" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.4" }
+retrom-db = { path = "./packages/db", version = "^0.4.5" }
+retrom-client = { path = "./packages/client", version = "^0.4.5" }
+retrom-service = { path = "./packages/service", version = "^0.4.5" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.4.5" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.5" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.5" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.5" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.4.4 -> 0.4.5
* `retrom-codegen`: 0.4.4 -> 0.4.5
* `retrom-db`: 0.4.4 -> 0.4.5
* `retrom-plugin-installer`: 0.4.4 -> 0.4.5
* `retrom-plugin-launcher`: 0.4.4 -> 0.4.5
* `retrom-plugin-service-client`: 0.4.4 -> 0.4.5
* `retrom-service`: 0.4.4 -> 0.4.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.4.5](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.4...retrom-v0.4.5) - 2024-11-22

### Fixes
- don't show empty platforms in fullscreen mode

    resolves [#182](https://github.com/JMBeresford/retrom/pull/182)



- EGL Bad Parameter error on some devices
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).