### PR TITLE
retrom-v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.7](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.6...retrom-v0.4.7) - 2024-12-13
+
+### Fixes
+- UI Tweaks
+
+
+
+### New
+- config panel
+
+    You can now configure certain server and client settings
+    from the File > Config menu item.
+
+
+
+
 ## [0.4.6](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.5...retrom-v0.4.6) - 2024-12-01
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "diesel",
  "prost",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "hyper 0.14.30",
  "hyper-rustls 0.25.0",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,14 +34,14 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.4.6" }
-retrom-client = { path = "./packages/client", version = "^0.4.6" }
-retrom-service = { path = "./packages/service", version = "^0.4.6" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.4.6" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.6" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.6" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.6" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.4.6" }
+retrom-db = { path = "./packages/db", version = "^0.4.7" }
+retrom-client = { path = "./packages/client", version = "^0.4.7" }
+retrom-service = { path = "./packages/service", version = "^0.4.7" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.4.7" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.7" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.7" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.7" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.4.7" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.4.6 -> 0.4.7
* `retrom-codegen`: 0.4.6 -> 0.4.7
* `retrom-db`: 0.4.6 -> 0.4.7
* `retrom-plugin-installer`: 0.4.6 -> 0.4.7
* `retrom-plugin-service-client`: 0.4.6 -> 0.4.7
* `retrom-plugin-steam`: 0.4.6 -> 0.4.7
* `retrom-plugin-launcher`: 0.4.6 -> 0.4.7
* `retrom-service`: 0.4.6 -> 0.4.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.4.7](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.6...retrom-v0.4.7) - 2024-12-13

### Fixes
- UI Tweaks



### New
- config panel

    You can now configure certain server and client settings
    from the File > Config menu item.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).