### PR TITLE
retrom-v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.8](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.7...retrom-v0.4.8) - 2024-12-15
+
+### Fixes
+- IPC communications
+
+    An upstream dependency used to (de)serialize JSON between various
+    layers of Retrom introduced a regression that broke certain
+    functionalities. As a consequence of this, the server config
+    file now uses camelCase as is standard for JSON. Existing configs
+    will continue to work.
+
+
+
+
 ## [0.4.7](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.6...retrom-v0.4.7) - 2024-12-13
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "diesel",
  "prost",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "hyper 0.14.30",
  "hyper-rustls 0.25.0",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,14 +34,14 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.4.7" }
-retrom-client = { path = "./packages/client", version = "^0.4.7" }
-retrom-service = { path = "./packages/service", version = "^0.4.7" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.4.7" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.7" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.7" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.7" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.4.7" }
+retrom-db = { path = "./packages/db", version = "^0.4.8" }
+retrom-client = { path = "./packages/client", version = "^0.4.8" }
+retrom-service = { path = "./packages/service", version = "^0.4.8" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.4.8" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.8" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.8" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.8" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.4.8" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.4.7 -> 0.4.8
* `retrom-codegen`: 0.4.7 -> 0.4.8
* `retrom-db`: 0.4.7 -> 0.4.8
* `retrom-plugin-installer`: 0.4.7 -> 0.4.8
* `retrom-plugin-service-client`: 0.4.7 -> 0.4.8
* `retrom-plugin-steam`: 0.4.7 -> 0.4.8
* `retrom-plugin-launcher`: 0.4.7 -> 0.4.8
* `retrom-service`: 0.4.7 -> 0.4.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.4.8](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.7...retrom-v0.4.8) - 2024-12-15

### Fixes
- IPC communications

    An upstream dependency used to (de)serialize JSON between various
    layers of Retrom introduced a regression that broke certain
    functionalities. As a consequence of this, the server config
    file now uses camelCase as is standard for JSON. Existing configs
    will continue to work.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).