### PR TITLE
retrom-v0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.10](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.9...retrom-v0.4.10) - 2024-12-28
+
+### Fixes
+- UI tweaks
+
+
+
+### New
+- persist window size and position
+
+    Retrom will now remember window state when
+    closed and re-opened.
+
+    resolves [#145](https://github.com/JMBeresford/retrom/pull/145)
+
+
+
+
 ## [0.4.9](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.8...retrom-v0.4.9) - 2024-12-24
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async-compression",
  "dotenvy",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "diesel",
  "prost",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "dotenvy",
  "futures",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "dotenvy",
  "hyper 0.14.30",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "hyper 0.14.30",
  "hyper-rustls 0.25.0",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules"]
 
 [workspace.package]
 edition = "2021"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,14 +34,14 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.4.9" }
-retrom-client = { path = "./packages/client", version = "^0.4.9" }
-retrom-service = { path = "./packages/service", version = "^0.4.9" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.4.9" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.9" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.9" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.9" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.4.9" }
+retrom-db = { path = "./packages/db", version = "^0.4.10" }
+retrom-client = { path = "./packages/client", version = "^0.4.10" }
+retrom-service = { path = "./packages/service", version = "^0.4.10" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.4.10" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.4.10" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.4.10" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.4.10" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.4.10" }
 futures = "0.3.30"
 bytes = "1.6.0"
 reqwest = { version = "0.12.3", features = [


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.4.9 -> 0.4.10
* `retrom-codegen`: 0.4.9 -> 0.4.10
* `retrom-db`: 0.4.9 -> 0.4.10
* `retrom-plugin-installer`: 0.4.9 -> 0.4.10
* `retrom-plugin-service-client`: 0.4.9 -> 0.4.10
* `retrom-plugin-steam`: 0.4.9 -> 0.4.10
* `retrom-plugin-launcher`: 0.4.9 -> 0.4.10
* `retrom-service`: 0.4.9 -> 0.4.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.4.10](https://github.com/JMBeresford/retrom/compare/retrom-v0.4.9...retrom-v0.4.10) - 2024-12-28

### Fixes
- UI tweaks



### New
- persist window size and position

    Retrom will now remember window state when
    closed and re-opened.

    resolves [#145](https://github.com/JMBeresford/retrom/pull/145)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).