### PR TITLE
retrom-v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4](https://github.com/JMBeresford/retrom/compare/retrom-v0.5.3...retrom-v0.5.4) - 2025-01-16
+
+### Bug Fixes
+- *(docker)* better default permissions
+
+
 ## [0.5.2](https://github.com/JMBeresford/retrom/compare/retrom-v0.5.1...retrom-v0.5.2) - 2025-01-15
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "config",
  "retrom-codegen",
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "dotenvy",
  "hyper 0.14.31",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hyper 0.14.31",
  "hyper-rustls 0.25.0",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules", "./packages/client/web"]
 
 [workspace.package]
 edition = "2021"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -34,16 +34,16 @@ tracing-futures = { version = "0.2.5", features = ["tokio", "futures"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.5.3" }
-retrom-client = { path = "./packages/client", version = "^0.5.3" }
-retrom-service = { path = "./packages/service", version = "^0.5.3" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.5.3" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.5.3" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.5.3" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.5.3" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.5.3" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.5.3" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.5.3" }
+retrom-db = { path = "./packages/db", version = "^0.5.4" }
+retrom-client = { path = "./packages/client", version = "^0.5.4" }
+retrom-service = { path = "./packages/service", version = "^0.5.4" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.5.4" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.5.4" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.5.4" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.5.4" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.5.4" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.5.4" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.5.4" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.5.3 -> 0.5.4
* `retrom-codegen`: 0.5.3 -> 0.5.4
* `retrom-db`: 0.5.3 -> 0.5.4
* `retrom-plugin-config`: 0.5.3 -> 0.5.4
* `retrom-plugin-installer`: 0.5.3 -> 0.5.4
* `retrom-plugin-service-client`: 0.5.3 -> 0.5.4
* `retrom-plugin-steam`: 0.5.3 -> 0.5.4
* `retrom-plugin-launcher`: 0.5.3 -> 0.5.4
* `retrom-plugin-standalone`: 0.5.3 -> 0.5.4
* `retrom-service`: 0.5.3 -> 0.5.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.5.4](https://github.com/JMBeresford/retrom/compare/retrom-v0.5.3...retrom-v0.5.4) - 2025-01-16

### Bug Fixes
- *(docker)* better default permissions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).