### PR TITLE
fix: support running service docker image as user

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -41,4 +41,9 @@ done
 # psql db dir needs 700 or 750 permissions
 chmod 750 /app/data/db
 
-exec runuser -u retrom "$@"
+if [ "$(id -u)" = 0 ]; then
+  exec runuser -u retrom "$@"
+else
+  exec "$@"
+fi
+


### PR DESCRIPTION
When running retrom service directly as a user (with `--user`) image, the container fails, because `runuser` cannot be run as non-root. This PR adds a simple fix, which checks for that, and acts accordingly.