### PR TITLE
retrom-v0.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.11](https://github.com/JMBeresford/retrom/compare/retrom-v0.7.10...retrom-v0.7.11) - 2025-02-11
+
+### Newly Added
+- UI tweaks
+
+- default profiles for newly added emulators
+
+- better default emulator visibility
+
+    The desktop client now lists the default emulator and
+    profile, where applicable, under the play button.
+
+    Additionally, you can now launch a game in any valid
+    emulator via the dropdown menu next to the play button.
+    This is useful for games that may want to opt-out of the
+    defaults.
+
+
+
+
 ## [0.7.10](https://github.com/JMBeresford/retrom/compare/retrom-v0.7.9...retrom-v0.7.10) - 2025-02-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5133,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "config",
  "retrom-codegen",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "dotenvy",
  "hyper 0.14.31",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "hyper 0.14.31",
  "hyper-rustls 0.25.0",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules", "./packages/client/web"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.10"
+version = "0.7.11"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -40,15 +40,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.10" }
-retrom-service = { path = "./packages/service", version = "^0.7.10" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.10" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.10" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.10" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.10" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.10" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.10" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.10" }
+retrom-db = { path = "./packages/db", version = "^0.7.11" }
+retrom-service = { path = "./packages/service", version = "^0.7.11" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.11" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.11" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.11" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.11" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.11" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.11" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.11" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.10 -> 0.7.11
* `retrom-codegen`: 0.7.10 -> 0.7.11
* `retrom-db`: 0.7.10 -> 0.7.11
* `retrom-plugin-config`: 0.7.10 -> 0.7.11
* `retrom-plugin-installer`: 0.7.10 -> 0.7.11
* `retrom-plugin-service-client`: 0.7.10 -> 0.7.11
* `retrom-plugin-steam`: 0.7.10 -> 0.7.11
* `retrom-plugin-launcher`: 0.7.10 -> 0.7.11
* `retrom-plugin-standalone`: 0.7.10 -> 0.7.11
* `retrom-service`: 0.7.10 -> 0.7.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.11](https://github.com/JMBeresford/retrom/compare/retrom-v0.7.10...retrom-v0.7.11) - 2025-02-11

### Newly Added
- UI tweaks

- default profiles for newly added emulators

- better default emulator visibility

    The desktop client now lists the default emulator and
    profile, where applicable, under the play button.

    Additionally, you can now launch a game in any valid
    emulator via the dropdown menu next to the play button.
    This is useful for games that may want to opt-out of the
    defaults.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).