### PR TITLE
Release: v0.7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.16](https://github.com/JMBeresford/retrom/compare/v0.7.15...v0.7.16) - 2025-04-03
+
+### Bug Fixes
+- macOS builds
+
+
 ## [0.7.15](https://github.com/JMBeresford/retrom/compare/retrom-v0.7.14...retrom-v0.7.15) - 2025-04-02
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "config",
  "retrom-codegen",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5171,7 +5171,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "dotenvy",
  "hyper 0.14.31",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "hyper 0.14.31",
  "hyper-rustls 0.25.0",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules", "./packages/client/web"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.15"
+version = "0.7.16"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -40,15 +40,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.15" }
-retrom-service = { path = "./packages/service", version = "^0.7.15" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.15" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.15" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.15" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.15" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.15" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.15" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.15" }
+retrom-db = { path = "./packages/db", version = "^0.7.16" }
+retrom-service = { path = "./packages/service", version = "^0.7.16" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.16" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.16" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.16" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.16" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.16" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.16" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.16" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.15 -> 0.7.16
* `retrom-codegen`: 0.7.15 -> 0.7.16
* `retrom-db`: 0.7.15 -> 0.7.16
* `retrom-plugin-config`: 0.7.15 -> 0.7.16
* `retrom-plugin-installer`: 0.7.15 -> 0.7.16
* `retrom-plugin-service-client`: 0.7.15 -> 0.7.16
* `retrom-plugin-steam`: 0.7.15 -> 0.7.16
* `retrom-plugin-launcher`: 0.7.15 -> 0.7.16
* `retrom-plugin-standalone`: 0.7.15 -> 0.7.16
* `retrom-service`: 0.7.15 -> 0.7.16

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.16](https://github.com/JMBeresford/retrom/compare/v0.7.15...v0.7.16) - 2025-04-03

### Bug Fixes
- macOS builds
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).