### PR TITLE
Release: v0.7.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "async_zip",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules", "./packages/client/web", "./packages/configs"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.21"
+version = "0.7.22"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -40,15 +40,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.21" }
-retrom-service = { path = "./packages/service", version = "^0.7.21" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.21" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.21" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.21" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.21" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.21" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.21" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.21" }
+retrom-db = { path = "./packages/db", version = "^0.7.22" }
+retrom-service = { path = "./packages/service", version = "^0.7.22" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.22" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.22" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.22" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.22" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.22" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.22" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.22" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.21 -> 0.7.22
* `retrom-codegen`: 0.7.21 -> 0.7.22
* `retrom-db`: 0.7.21 -> 0.7.22
* `retrom-plugin-config`: 0.7.21 -> 0.7.22
* `retrom-plugin-installer`: 0.7.21 -> 0.7.22
* `retrom-plugin-service-client`: 0.7.21 -> 0.7.22
* `retrom-plugin-steam`: 0.7.21 -> 0.7.22
* `retrom-plugin-launcher`: 0.7.21 -> 0.7.22
* `retrom-plugin-standalone`: 0.7.21 -> 0.7.22
* `retrom-service`: 0.7.21 -> 0.7.22

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.21](https://github.com/JMBeresford/retrom/compare/v0.7.20...v0.7.21) - 2025-05-03

### Bug Fixes
- sort fullscreen games alphabetically

- fetch default profile for new emulators

    When a new emulator is created, its default profile
    will now be present in the profile list immediately.

    fixes [#286](https://github.com/JMBeresford/retrom/pull/286)





### Newly Added
- scroll by character in fullscreen mode

    You can now use the list of characters on the left
    of alphabetically sorted game lists in fullscreen mode
    to scroll to games starting with that character. This is
    useful for large libraries that are hard to navigate in
    fullscreen mode.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).