### PR TITLE
Release: v0.7.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.24](https://github.com/JMBeresford/retrom/compare/v0.7.23...v0.7.24) - 2025-06-15
+
+### Bug Fixes
+- auto-updater
+
+    There were certain cases in which the auto-updater was failing to find
+    new updates, this has been resolved.
+
+    Additionally, macOS releases are now able to leverage the auto-updater
+    -- no longer requiring macOS clients to be manually updated via
+    downloading the new release.
+
+
+
+
 ## [0.7.23](https://github.com/JMBeresford/retrom/compare/v0.7.22...v0.7.23) - 2025-06-15
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5327,7 +5327,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.23"
+version = "0.7.24"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules", "./packages/client/web", "./packages/configs"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.23"
+version = "0.7.24"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -40,15 +40,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.23" }
-retrom-service = { path = "./packages/service", version = "^0.7.23" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.23" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.23" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.23" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.23" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.23" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.23" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.23" }
+retrom-db = { path = "./packages/db", version = "^0.7.24" }
+retrom-service = { path = "./packages/service", version = "^0.7.24" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.24" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.24" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.24" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.24" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.24" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.24" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.24" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.23 -> 0.7.24
* `retrom-codegen`: 0.7.23 -> 0.7.24
* `retrom-db`: 0.7.23 -> 0.7.24
* `retrom-plugin-config`: 0.7.23 -> 0.7.24
* `retrom-plugin-installer`: 0.7.23 -> 0.7.24
* `retrom-plugin-service-client`: 0.7.23 -> 0.7.24
* `retrom-plugin-steam`: 0.7.23 -> 0.7.24
* `retrom-plugin-launcher`: 0.7.23 -> 0.7.24
* `retrom-plugin-standalone`: 0.7.23 -> 0.7.24
* `retrom-service`: 0.7.23 -> 0.7.24

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.24](https://github.com/JMBeresford/retrom/compare/v0.7.23...v0.7.24) - 2025-06-15

### Bug Fixes
- auto-updater

    There were certain cases in which the auto-updater was failing to find
    new updates, this has been resolved.

    Additionally, macOS releases are now able to leverage the auto-updater
    -- no longer requiring macOS clients to be manually updated via
    downloading the new release.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).