### PR TITLE
Release: v0.7.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.27](https://github.com/JMBeresford/retrom/compare/v0.7.26...v0.7.27) - 2025-06-23
+
+### Newly Added
+- initial switch gamepad mapping
+
+    Initial support for the following switch gamepads
+    and their respective default mappings have been added:
+
+    Switch Pro Controller, Switch JoyCons, Switch N64 Controller
+
+    resolves [#330](https://github.com/JMBeresford/retrom/pull/330)
+
+
+
+
 ## [0.7.26](https://github.com/JMBeresford/retrom/compare/v0.7.25...v0.7.26) - 2025-06-22
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["**/node_modules", "./packages/client/web", "./packages/configs"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.26"
+version = "0.7.27"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -45,15 +45,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.26" }
-retrom-service = { path = "./packages/service", version = "^0.7.26" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.26" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.26" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.26" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.26" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.26" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.26" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.26" }
+retrom-db = { path = "./packages/db", version = "^0.7.27" }
+retrom-service = { path = "./packages/service", version = "^0.7.27" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.27" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.27" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.27" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.27" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.27" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.27" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.27" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.26 -> 0.7.27
* `retrom-codegen`: 0.7.26 -> 0.7.27
* `retrom-db`: 0.7.26 -> 0.7.27
* `retrom-plugin-config`: 0.7.26 -> 0.7.27
* `retrom-plugin-installer`: 0.7.26 -> 0.7.27
* `retrom-plugin-service-client`: 0.7.26 -> 0.7.27
* `retrom-plugin-steam`: 0.7.26 -> 0.7.27
* `retrom-plugin-launcher`: 0.7.26 -> 0.7.27
* `retrom-plugin-standalone`: 0.7.26 -> 0.7.27
* `retrom-service`: 0.7.26 -> 0.7.27

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.27](https://github.com/JMBeresford/retrom/compare/v0.7.26...v0.7.27) - 2025-06-23

### Newly Added
- initial switch gamepad mapping

    Initial support for the following switch gamepads
    and their respective default mappings have been added:

    Switch Pro Controller, Switch JoyCons, Switch N64 Controller

    resolves [#330](https://github.com/JMBeresford/retrom/pull/330)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).