### PR TITLE
Release: v0.7.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["**/node_modules", "./packages/client-web", "./packages/configs"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.28"
+version = "0.7.29"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -44,15 +44,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.28" }
-retrom-service = { path = "./packages/service", version = "^0.7.28" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.28" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.28" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.28" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.28" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.28" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.28" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.28" }
+retrom-db = { path = "./packages/db", version = "^0.7.29" }
+retrom-service = { path = "./packages/service", version = "^0.7.29" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.29" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.29" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.29" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.29" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.29" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.29" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.29" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.28 -> 0.7.29
* `retrom-codegen`: 0.7.28 -> 0.7.29
* `retrom-db`: 0.7.28 -> 0.7.29
* `retrom-plugin-config`: 0.7.28 -> 0.7.29
* `retrom-plugin-installer`: 0.7.28 -> 0.7.29
* `retrom-plugin-service-client`: 0.7.28 -> 0.7.29
* `retrom-plugin-steam`: 0.7.28 -> 0.7.29
* `retrom-plugin-launcher`: 0.7.28 -> 0.7.29
* `retrom-plugin-standalone`: 0.7.28 -> 0.7.29
* `retrom-service`: 0.7.28 -> 0.7.29

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.28](https://github.com/JMBeresford/retrom/compare/v0.7.27...v0.7.28) - 2025-06-30

### Newly Added
- opt-in installation of games in standalone mode

    You can now configure standalone mode to require 'installing'
    games as if they were hosted on a dedicated Retrom server. This
    is useful in cases where you are running standalone mode but accessing
    a library from a network drive. Installing in such cases ensures you
    have a truly local copy of your installed games.

    This also fixes a bug where in some cases standalone mode was
    unconditionally requiring installation of games.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).