### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,10 +3,14 @@
   "parallel": 5,
   "targetDefaults": {
     "dev": {
-      "syncGenerators": ["@nx/js:typescript-sync"]
+      "syncGenerators": [
+        "@nx/js:typescript-sync"
+      ]
     },
     "build": {
-      "syncGenerators": ["@nx/js:typescript-sync"]
+      "syncGenerators": [
+        "@nx/js:typescript-sync"
+      ]
     },
     "prettier:format": {
       "executor": "nx:run-commands",
@@ -46,28 +50,40 @@
     },
     "cargo:run": {
       "executor": "@monodon/rust:run",
-      "dependsOn": ["^cargo:build"],
+      "dependsOn": [
+        "^cargo:build"
+      ],
       "continuous": true
     },
     "cargo:lint": {
-      "dependsOn": ["^cargo:lint"],
+      "dependsOn": [
+        "^cargo:lint"
+      ],
       "executor": "@monodon/rust:lint",
       "configurations": {
         "fix": {
-          "args": ["--fix"]
+          "args": [
+            "--fix"
+          ]
         }
       }
     },
     "eslint:lint": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "configurations": {
         "fix": {
-          "args": ["--fix"]
+          "args": [
+            "--fix"
+          ]
         }
       }
     },
     "cargo:build": {
-      "dependsOn": ["^cargo:build"],
+      "dependsOn": [
+        "^cargo:build"
+      ],
       "executor": "@monodon/rust:build",
       "configurations": {
         "release": {
@@ -95,5 +111,6 @@
       }
     },
     "@monodon/rust"
-  ]
+  ],
+  "nxCloudId": "68671fe5462f6a349cd487bd"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/6866ec6c462f6a349cd487a4/workspaces/68671fe5462f6a349cd487bd

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.