### PR TITLE
Release: v0.7.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
-version = "0.7.28"
+version = "0.7.29"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -49,15 +49,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.28" }
-retrom-service = { path = "./packages/service", version = "^0.7.28" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.28" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.28" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.28" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.28" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.28" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.28" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.28" }
+retrom-db = { path = "./packages/db", version = "^0.7.29" }
+retrom-service = { path = "./packages/service", version = "^0.7.29" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.29" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.29" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.29" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.29" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.29" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.29" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.29" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [workspace]
 resolver = "2"
 members = ["./packages/*", "./plugins/*"]
-exclude = ["**/node_modules", "./packages/client-web", "./packages/ui", "./packages/configs"]
+exclude = [
+  "**/node_modules",
+  "./packages/client-web",
+  "./packages/ui",
+  "./packages/configs",
+]
 
 [workspace.package]
 edition = "2021"

--- a/packages/client-web/src/components/modals/manage-emulators/emulator-list.tsx
+++ b/packages/client-web/src/components/modals/manage-emulators/emulator-list.tsx
@@ -359,7 +359,6 @@ export function EmulatorList(props: {
 
                             <FormField
                               control={form.control}
-                              disabled={builtIn}
                               name={
                                 `emulators.${emulator.id}.operatingSystems` as const
                               }
@@ -370,7 +369,7 @@ export function EmulatorList(props: {
                                     <FormControl>
                                       <PopoverTrigger asChild>
                                         <Button
-                                          disabled={field.disabled}
+                                          disabled={builtIn}
                                           variant="outline"
                                           role="combobox"
                                           className={cn(

--- a/packages/client-web/src/lib/emulatorjs/gamepad.d.ts
+++ b/packages/client-web/src/lib/emulatorjs/gamepad.d.ts
@@ -6,8 +6,8 @@ export declare class GamepadHandler {
   updateGamepadState(): void;
   dispatchEvent(name: unknown, arg: unknown): void;
   on(name: unknown, cb: unknown): void;
-  getButtonLabel(index: unknown): null | string;
-  getAxisLabel(axis: unknown, value: unknown): string;
+  getButtonLabel(index: number): null | string;
+  getAxisLabel(axis: string, value: number): string | null;
 }
 
 declare global {

--- a/packages/client-web/src/providers/emulator-js/control-options.tsx
+++ b/packages/client-web/src/providers/emulator-js/control-options.tsx
@@ -46,6 +46,10 @@ export type ControlOptions = {
   keyLookup: EmulatorJS["keyLookup"];
   getKeyLabel: (key: number) => string;
   getButtonLabel: GamepadHandler["getButtonLabel"];
+  getAxisLabel: (
+    axis: number,
+    value: number,
+  ) => ReturnType<GamepadHandler["getAxisLabel"]>;
   pauseInput: () => void;
   resumeInput: () => void;
 };
@@ -192,6 +196,24 @@ export function ControlOptionsProvider(props: PropsWithChildren) {
     [emulatorJS],
   );
 
+  const getAxisLabel = useCallback(
+    (axis: number, _value: number) => {
+      const axisName = [
+        "LEFT_STICK_X",
+        "LEFT_STICK_Y",
+        "RIGHT_STICK_X",
+        "RIGHT_STICK_Y",
+      ][axis];
+
+      // EJS requires axis values have a magnitude of 0.5 for this helper
+      // method to return a label, so we multiply by 10 to include anything
+      // reasonable. Thresholds should be queried prior to this call.
+      const value = _value * 10;
+      return emulatorJS.gamepad.getAxisLabel(axisName, value);
+    },
+    [emulatorJS],
+  );
+
   const pauseInput = useCallback(() => {
     emulatorJS.gamepad.on("axischanged", () => {});
     emulatorJS.gamepad.on("buttondown", () => {});
@@ -222,6 +244,7 @@ export function ControlOptionsProvider(props: PropsWithChildren) {
       keyLookup,
       getKeyLabel,
       getButtonLabel,
+      getAxisLabel,
       pauseInput,
       resumeInput,
     }),
@@ -236,6 +259,7 @@ export function ControlOptionsProvider(props: PropsWithChildren) {
       keyLookup,
       getKeyLabel,
       getButtonLabel,
+      getAxisLabel,
       pauseInput,
       resumeInput,
     ],

--- a/packages/client-web/src/providers/gamepad/index.tsx
+++ b/packages/client-web/src/providers/gamepad/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "./event";
 import { getControllerMapping } from "./controller-ids";
 import { ControllerMapping } from "./maps";
+import { axisValueToAxisState, GamepadAxisState } from "./utils";
 
 export interface RetromGamepad {
   gamepad: Gamepad;
@@ -105,13 +106,14 @@ export function GamepadProvider(props: PropsWithChildren) {
         for (let i = 0; i < pad.axes.length; i++) {
           const value = pad.axes.at(i) ?? 0;
           const cachedValue = inputCache.axes.get(index)?.at(i) ?? 0;
-          const currentlyActive = value >= 0.5;
-          const previouslyActive = cachedValue >= 0.5;
 
-          if (currentlyActive !== previouslyActive) {
+          const currentState = axisValueToAxisState(value);
+          const previousState = axisValueToAxisState(cachedValue);
+
+          if (currentState !== previousState) {
             changed = true;
 
-            if (currentlyActive) {
+            if (currentState !== GamepadAxisState.Neutral) {
               node?.dispatchEvent(
                 new GamepadAxisActiveEvent({
                   gamepad: pad,

--- a/packages/client-web/src/providers/gamepad/utils.ts
+++ b/packages/client-web/src/providers/gamepad/utils.ts
@@ -1,0 +1,18 @@
+export enum GamepadAxisState {
+  "Positive" = "Positive",
+  "Negative" = "Negative",
+  "Neutral" = "Neutral",
+}
+
+export function axisValueToAxisState(
+  value: number,
+  threshold: number = 0.1,
+): GamepadAxisState {
+  if (value > threshold) {
+    return GamepadAxisState.Positive;
+  } else if (value < -threshold) {
+    return GamepadAxisState.Negative;
+  }
+
+  return GamepadAxisState.Neutral;
+}

--- a/packages/client-web/src/providers/hotkeys/mapping.tsx
+++ b/packages/client-web/src/providers/hotkeys/mapping.tsx
@@ -15,6 +15,10 @@ const DefaultHotkeyToKeyboardHotkey: Record<Hotkey, KeyboardEvent["key"]> = {
   PAGE_RIGHT: "e",
 } as const;
 
+/**
+ * Follows the standard mapping defined in the Gamepad API spec
+ * @see https://w3c.github.io/gamepad/#dfn-standard-gamepad
+ **/
 const DefaultHotkeyToGamepadButton: Record<Hotkey, number> = {
   ACCEPT: 0,
   BACK: 1,
@@ -69,8 +73,6 @@ export const useHotkeyMapping = create<HotkeyMappingState>()(
 
       setKeyboardMap: (cb) => {
         const next = cb(get().hotkeyToKeyboard);
-
-        console.log({ next });
 
         return set({
           hotkeyToKeyboard: next,

--- a/packages/client-web/src/routes/play/$gameId/_layout/-utils/overlay/control-options.tsx
+++ b/packages/client-web/src/routes/play/$gameId/_layout/-utils/overlay/control-options.tsx
@@ -172,7 +172,7 @@ const RecordInput = memo(function RecordInput(props: {
   const [recording, setRecording] = useState(false);
   const { player, buttonId, gamepad } = props;
   const { gamepads } = useGamepadContext();
-  const { setBindings, keyLookup, getKeyLabel, getButtonLabel } =
+  const { setBindings, keyLookup, getKeyLabel, getButtonLabel, getAxisLabel } =
     useControlOptions();
   const bindings = usePlayerControls(player);
 
@@ -244,16 +244,23 @@ const RecordInput = memo(function RecordInput(props: {
 
       if (e instanceof GamepadButtonDownEvent) {
         const { button } = e.detail;
-        if (!e.detail.gamepad.buttons[button]?.pressed) return;
 
         const label = getButtonLabel(button);
         if (label) {
           setBinding(label);
         }
         setRecording(false);
+      } else if (e instanceof GamepadAxisActiveEvent) {
+        const { axis, value } = e.detail;
+
+        const label = getAxisLabel(axis, value);
+        if (label) {
+          setBinding(label);
+        }
+        setRecording(false);
       }
     },
-    [recording, gamepad, setBinding, getButtonLabel],
+    [recording, gamepad, setBinding, getButtonLabel, getAxisLabel],
   );
 
   useLayoutEffect(() => {

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -7,7 +7,8 @@ license.workspace = true
 edition.workspace = true
 description = "The Retrom video game library client"
 rust-version = "1.80"
-exclude = ["./node_modules", "./web/node_modules/", "./web/dist/"]
+exclude = ["./node_modules"]
+include = ["../client-web/**", "../ui/**"]
 
 [[bin]]
 name = "Retrom"

--- a/packages/db/migrations/2025-07-13-234604_fix-builtin-emu-os-lists/down.sql
+++ b/packages/db/migrations/2025-07-13-234604_fix-builtin-emu-os-lists/down.sql
@@ -1,0 +1,5 @@
+-- Nothing to down here, this migration is only to fix a regression
+-- that led to mutation of data that should be static. The following
+-- should be a no-op.
+update emulators set operating_systems = array[3]
+where built_in = true;

--- a/packages/db/migrations/2025-07-13-234604_fix-builtin-emu-os-lists/up.sql
+++ b/packages/db/migrations/2025-07-13-234604_fix-builtin-emu-os-lists/up.sql
@@ -1,0 +1,2 @@
+update emulators set operating_systems = array[3]
+where built_in = true;


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.28 -> 0.7.29
* `retrom-codegen`: 0.7.28 -> 0.7.29
* `retrom-db`: 0.7.28 -> 0.7.29
* `retrom-plugin-config`: 0.7.28 -> 0.7.29
* `retrom-plugin-installer`: 0.7.28 -> 0.7.29
* `retrom-plugin-service-client`: 0.7.28 -> 0.7.29
* `retrom-plugin-steam`: 0.7.28 -> 0.7.29
* `retrom-plugin-launcher`: 0.7.28 -> 0.7.29
* `retrom-plugin-standalone`: 0.7.28 -> 0.7.29
* `retrom-service`: 0.7.28 -> 0.7.29

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.28](https://github.com/JMBeresford/retrom/compare/v0.7.27...v0.7.28) - 2025-06-30

### Newly Added
- opt-in installation of games in standalone mode

    You can now configure standalone mode to require 'installing'
    games as if they were hosted on a dedicated Retrom server. This
    is useful in cases where you are running standalone mode but accessing
    a library from a network drive. Installing in such cases ensures you
    have a truly local copy of your installed games.

    This also fixes a bug where in some cases standalone mode was
    unconditionally requiring installation of games.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).