### PR TITLE
Release: v0.7.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.32](https://github.com/JMBeresford/retrom/compare/v0.7.31...v0.7.32) - 2025-08-10
+
+### Bug Fixes
+- download game button
+
+    The download game button now uses the correct
+    download URL.
+
+    fixes [#377](https://github.com/JMBeresford/retrom/pull/377)
+
+
+
+
+
+### Newly Added
+- download game from drop-down
+
+    There is now a drop-down option to download
+    a game on its details page.
+
+    fixes [#377](https://github.com/JMBeresford/retrom/pull/377)
+
+
+
+
 ## [0.7.31](https://github.com/JMBeresford/retrom/compare/v0.7.30...v0.7.31) - 2025-08-03
 
 ### Newly Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,7 +5326,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5496,7 +5496,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["./packages/client-web", "./packages/ui", "./packages/configs"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.31"
+version = "0.7.32"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -44,15 +44,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.31" }
-retrom-service = { path = "./packages/service", version = "^0.7.31" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.31" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.31" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.31" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.31" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.31" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.31" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.31" }
+retrom-db = { path = "./packages/db", version = "^0.7.32" }
+retrom-service = { path = "./packages/service", version = "^0.7.32" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.32" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.32" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.32" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.32" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.32" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.32" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.32" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.31 -> 0.7.32
* `retrom-codegen`: 0.7.31 -> 0.7.32
* `retrom-db`: 0.7.31 -> 0.7.32
* `retrom-plugin-config`: 0.7.31 -> 0.7.32
* `retrom-plugin-installer`: 0.7.31 -> 0.7.32
* `retrom-plugin-service-client`: 0.7.31 -> 0.7.32
* `retrom-plugin-steam`: 0.7.31 -> 0.7.32
* `retrom-plugin-launcher`: 0.7.31 -> 0.7.32
* `retrom-plugin-standalone`: 0.7.31 -> 0.7.32
* `retrom-service`: 0.7.31 -> 0.7.32

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.32](https://github.com/JMBeresford/retrom/compare/v0.7.31...v0.7.32) - 2025-08-10

### Bug Fixes
- download game button

    The download game button now uses the correct
    download URL.

    fixes [#377](https://github.com/JMBeresford/retrom/pull/377)





### Newly Added
- download game from drop-down

    There is now a drop-down option to download
    a game on its details page.

    fixes [#377](https://github.com/JMBeresford/retrom/pull/377)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).