### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -111,6 +111,9 @@ jobs:
 
   merge-digests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       DOCKER_METADATA_OUTPUT_JSON: ${{ needs.build-images.outputs.metadata-json }}
       VERSION: ${{ fromJSON(needs.build-images.outputs.metadata-json).labels['org.opencontainers.image.version'] }}


### PR DESCRIPTION
Potential fix for [https://github.com/JMBeresford/retrom/security/code-scanning/5](https://github.com/JMBeresford/retrom/security/code-scanning/5)

To fix the problem, add a `permissions` block to the `merge-digests` job in `.github/workflows/publish-images.yml`. This block should grant only the minimum permissions required for the job to function. Since the job does not interact with the repository contents (no code checkout, no pushing, no issue or PR manipulation), the minimal permission is likely `contents: read`. If the job needs to push to the GitHub Container Registry, it may also require `packages: write`. However, in this job, the Docker login and manifest push are performed using the `GITHUB_TOKEN`, so `packages: write` is likely required. Therefore, set:

```yaml
permissions:
  contents: read
  packages: write
```

Insert this block under the `merge-digests` job definition, at the same indentation level as `runs-on`, `env`, etc.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
