### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Verify
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/JMBeresford/retrom/security/code-scanning/4](https://github.com/JMBeresford/retrom/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the permissions granted to the `GITHUB_TOKEN`. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. Based on the workflow steps, the minimal required permission is `contents: read`, which allows the workflow to check out code and read repository contents. No steps require write access to issues, pull requests, or other resources. The change should be made at the top of the `.github/workflows/verify.yml` file, after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
