### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-upstream-apis.yml
+++ b/.github/workflows/update-upstream-apis.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   update-igdb-api:
     name: Update IGDB API
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.RELEASE_PLZ_GH_TOKEN }}


### PR DESCRIPTION
Potential fix for [https://github.com/JMBeresford/retrom/security/code-scanning/3](https://github.com/JMBeresford/retrom/security/code-scanning/3)

To fix the problem, we should add a `permissions` block to the workflow or to the specific job. The minimal permissions required for this workflow are `contents: write` (to push commits) and `pull-requests: write` (to create/update PRs). These should be set at the job level for `update-igdb-api`, or at the workflow level if all jobs require the same permissions. Since only one job is present, either location is acceptable, but job-level is slightly more precise. The change should be made by adding the following block under the job definition (after line 11):

```yaml
permissions:
  contents: write
  pull-requests: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
