### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     name: Release-plz
     permissions:
       contents: write
+      pull-requests: write
     outputs:
       released: ${{ steps.release.outputs.releases_created }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/JMBeresford/retrom/security/code-scanning/2](https://github.com/JMBeresford/retrom/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or to the specific job. The minimal starting point is `contents: read`, but since the workflow uses the `MarcoIeni/release-plz-action`, which typically creates releases and may need to write to repository contents and/or create pull requests, you may need to grant additional permissions such as `contents: write` and possibly `pull-requests: write`. However, the safest fix is to start with `contents: write` (since releases require write access to repository contents) and add others only if required by the workflow. The change should be made in `.github/workflows/release.yml`, either at the root level (applies to all jobs) or within the `release-plz` job (applies only to that job). Since only one job is present, either location is acceptable, but job-level is more precise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
