### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -11,6 +11,8 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
 jobs:
   announce-to-discord:
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/JMBeresford/retrom/security/code-scanning/1](https://github.com/JMBeresford/retrom/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/announce.yml`. The block should be placed at the top level (before `jobs:`) to apply to all jobs in the workflow, unless a job needs more specific permissions. Since the workflow only announces releases and does not require write access to repository contents, the minimal permission required is `contents: read`. This change restricts the GITHUB_TOKEN to read-only access to repository contents, following the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
