### PR TITLE
Release: v0.7.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5479,7 +5479,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5517,7 +5517,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["./packages/client-web", "./packages/ui", "./packages/configs"]
 
 [workspace.package]
 edition = "2021"
-version = "0.7.33"
+version = "0.7.34"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -53,15 +53,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.33" }
-retrom-service = { path = "./packages/service", version = "^0.7.33" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.33" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.33" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.33" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.33" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.33" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.33" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.33" }
+retrom-db = { path = "./packages/db", version = "^0.7.34" }
+retrom-service = { path = "./packages/service", version = "^0.7.34" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.34" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.34" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.34" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.34" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.34" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.34" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.34" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.33 -> 0.7.34
* `retrom-codegen`: 0.7.33 -> 0.7.34
* `retrom-db`: 0.7.33 -> 0.7.34
* `retrom-plugin-config`: 0.7.33 -> 0.7.34
* `retrom-plugin-installer`: 0.7.33 -> 0.7.34
* `retrom-plugin-service-client`: 0.7.33 -> 0.7.34
* `retrom-plugin-steam`: 0.7.33 -> 0.7.34
* `retrom-plugin-launcher`: 0.7.33 -> 0.7.34
* `retrom-plugin-standalone`: 0.7.33 -> 0.7.34
* `retrom-service`: 0.7.33 -> 0.7.34

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.33](https://github.com/JMBeresford/retrom/compare/v0.7.32...v0.7.33) - 2025-08-24

### Newly Added
- cache metadata images on server

    Retrom now caches all remote image files on
    the server, and the client will fetch those
    copies instead of accessing the external URLs
    they were sourced from.

    If a file is not currently cached, the client
    will still use the upstream URL -- but the file
    will be cached for next time.

    fixes [#366](https://github.com/JMBeresford/retrom/pull/366)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).