### PR TITLE
Release: v0.7.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5370,11 +5370,11 @@ dependencies = [
 
 [[package]]
 name = "retrom-client-web"
-version = "0.7.36"
+version = "0.7.37"
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
-version = "0.7.36"
+version = "0.7.37"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -61,15 +61,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.36" }
-retrom-service = { path = "./packages/service", version = "^0.7.36" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.36" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.36" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.36" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.36" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.36" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.36" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.36" }
+retrom-db = { path = "./packages/db", version = "^0.7.37" }
+retrom-service = { path = "./packages/service", version = "^0.7.37" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.37" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.37" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.37" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.37" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.37" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.37" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.37" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.36 -> 0.7.37
* `retrom-codegen`: 0.7.36 -> 0.7.37
* `retrom-db`: 0.7.36 -> 0.7.37
* `retrom-plugin-config`: 0.7.36 -> 0.7.37
* `retrom-plugin-installer`: 0.7.36 -> 0.7.37
* `retrom-plugin-service-client`: 0.7.36 -> 0.7.37
* `retrom-plugin-steam`: 0.7.36 -> 0.7.37
* `retrom-plugin-launcher`: 0.7.36 -> 0.7.37
* `retrom-plugin-standalone`: 0.7.36 -> 0.7.37
* `retrom-service`: 0.7.36 -> 0.7.37
* `retrom-client-web`: 0.7.36 -> 0.7.37

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.36](https://github.com/JMBeresford/retrom/compare/v0.7.35...v0.7.36) - 2025-09-05

### Bug Fixes
- *(Docker)* graceful shutdown of server and DB

    fixes [#396](https://github.com/JMBeresford/retrom/pull/396)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).