### PR TITLE
Release: v0.7.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.39](https://github.com/JMBeresford/retrom/compare/v0.7.38...v0.7.39) - 2025-09-30
+
+### Newly Added
+- installation manager ([#406](https://github.com/JMBeresford/retrom/pull/406))
+
+    Game installations are now shown in the new installation dashboard,
+    in addition other relevant locations like the library side bar etc. The dashboard
+    allows you to view the status of and manage installs in the following ways:
+
+    - Cancel installations
+    - Immediately install a queued installation, pausing the currently active one
+    - See installation speed and progress at a glance for all installations
+    - See recently installed games
+
+
+
+
 ## [0.7.38](https://github.com/JMBeresford/retrom/compare/v0.7.37...v0.7.38) - 2025-09-20
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - See installation speed and progress at a glance for all installations
     - See recently installed games
 
+    **Screenshots**
 
+    ![Screenshot 1](https://github.com/user-attachments/assets/5b360d3c-be83-4136-924f-10c8b26b020e)
+
+    ![Screenshot 2](https://github.com/user-attachments/assets/952d2f32-4c30-489d-8975-763ed884ab79)
 
 
 ## [0.7.38](https://github.com/JMBeresford/retrom/compare/v0.7.37...v0.7.38) - 2025-09-20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-client"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5370,11 +5370,11 @@ dependencies = [
 
 [[package]]
 name = "retrom-client-web"
-version = "0.7.38"
+version = "0.7.39"
 
 [[package]]
 name = "retrom-codegen"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "diesel",
  "prost 0.12.6",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-db"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-config"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "config",
  "prost 0.12.6",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-installer"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "dotenvy",
  "futures",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-launcher"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "dotenvy",
  "hyper 0.14.32",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-service-client"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-standalone"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "local-ip-address",
  "retrom-codegen",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-plugin-steam"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "notify",
  "retrom-codegen",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "retrom-service"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "async-compression",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
-version = "0.7.38"
+version = "0.7.39"
 authors = ["John Beresford <jberesford@volcaus.com>"]
 license = "GPL-3.0"
 readme = "./README.md"
@@ -62,15 +62,15 @@ tracing-subscriber = { version = "0.3.18", features = [
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["io", "compat"] }
 dotenvy = "0.15.7"
-retrom-db = { path = "./packages/db", version = "^0.7.38" }
-retrom-service = { path = "./packages/service", version = "^0.7.38" }
-retrom-codegen = { path = "./packages/codegen", version = "^0.7.38" }
-retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.38" }
-retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.38" }
-retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.38" }
-retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.38" }
-retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.38" }
-retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.38" }
+retrom-db = { path = "./packages/db", version = "^0.7.39" }
+retrom-service = { path = "./packages/service", version = "^0.7.39" }
+retrom-codegen = { path = "./packages/codegen", version = "^0.7.39" }
+retrom-plugin-installer = { path = "./plugins/retrom-plugin-installer", version = "^0.7.39" }
+retrom-plugin-launcher = { path = "./plugins/retrom-plugin-launcher", version = "^0.7.39" }
+retrom-plugin-service-client = { path = "./plugins/retrom-plugin-service-client", version = "^0.7.39" }
+retrom-plugin-steam = { path = "./plugins/retrom-plugin-steam", version = "^0.7.39" }
+retrom-plugin-config = { path = "./plugins/retrom-plugin-config", version = "^0.7.39" }
+retrom-plugin-standalone = { path = "./plugins/retrom-plugin-standalone", version = "^0.7.39" }
 config = { version = "0.13.4", features = ["json5"] }
 futures = "0.3.30"
 bytes = "1.6.0"


### PR DESCRIPTION
## 🤖 New release
* `retrom-client`: 0.7.38 -> 0.7.39
* `retrom-codegen`: 0.7.38 -> 0.7.39
* `retrom-db`: 0.7.38 -> 0.7.39
* `retrom-plugin-config`: 0.7.38 -> 0.7.39
* `retrom-plugin-installer`: 0.7.38 -> 0.7.39
* `retrom-plugin-service-client`: 0.7.38 -> 0.7.39
* `retrom-plugin-steam`: 0.7.38 -> 0.7.39
* `retrom-plugin-launcher`: 0.7.38 -> 0.7.39
* `retrom-plugin-standalone`: 0.7.38 -> 0.7.39
* `retrom-service`: 0.7.38 -> 0.7.39
* `retrom-client-web`: 0.7.38 -> 0.7.39

<details><summary><i><b>Changelog</b></i></summary><p>

## `retrom-service`
<blockquote>

## [0.7.39](https://github.com/JMBeresford/retrom/compare/v0.7.38...v0.7.39) - 2025-09-30

### Newly Added
- installation manager ([#406](https://github.com/JMBeresford/retrom/pull/406))

    Game installations are now shown in the new installation dashboard,
    in addition other relevant locations like the library side bar etc. The dashboard
    allows you to view the status of and manage installs in the following ways:

    - Cancel installations
    - Immediately install a queued installation, pausing the currently active one
    - See installation speed and progress at a glance for all installations
    - See recently installed games

    **Screenshots**

    ![Screenshot 0](https://github.com/user-attachments/assets/5b360d3c-be83-4136-924f-10c8b26b020e)

    ![Screenshot 1](https://github.com/user-attachments/assets/952d2f32-4c30-489d-8975-763ed884ab79)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).