### PR TITLE
chore(nix): automatically pick up proper version

### DIFF
--- a/nix/pkgs/retrom-service/package.nix
+++ b/nix/pkgs/retrom-service/package.nix
@@ -14,18 +14,20 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "retrom-service";
-  version = "0.7.53";
+  inherit ((builtins.fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
 
   src = lib.cleanSourceWith {
     src = ../../../.;
-    filter = path: _: !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
-      /nix
-      /flake.nix
-      /flake.lock
+    filter =
+      path: _:
+      !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
+        /nix
+        /flake.nix
+        /flake.lock
 
-      /.github
-      /.gitignore
-    ]);
+        /.github
+        /.gitignore
+      ]);
   };
 
   pnpmDeps = fetchPnpmDeps {

--- a/nix/pkgs/retrom-unwrapped/package.nix
+++ b/nix/pkgs/retrom-unwrapped/package.nix
@@ -19,18 +19,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "retrom";
-  version = "0.7.53";
+  inherit ((builtins.fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
 
   src = lib.cleanSourceWith {
     src = ../../../.;
-    filter = path: _: !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
-      /nix
-      /flake.nix
-      /flake.lock
+    filter =
+      path: _:
+      !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
+        /nix
+        /flake.nix
+        /flake.lock
 
-      /.github
-      /.gitignore
-    ]);
+        /.github
+        /.gitignore
+      ]);
   };
 
   pnpmDeps = fetchPnpmDeps {


### PR DESCRIPTION
For some reason, this amazing nix-support contribution went over my head :) 

I noticed, that the package versions in both client and servers are hardcoded - which will get stale pretty quick (actually already did, as retrom 0.7.54 build as 0.7.53 from nix perspective). This is a little change, which picks up the version number from the `Cargo.toml` file (which I assume will alwyas be up to date), to save maintainers from keeping the version in multiple places.