### PR TITLE
[Draft] DOSBox Pure: cloud saves (ZIP-direct + restore timing) and MT-32 system ROMs

### DIFF
--- a/packages/client-web/src/lib/emulatorjs/GameManager.d.ts
+++ b/packages/client-web/src/lib/emulatorjs/GameManager.d.ts
@@ -5,6 +5,7 @@ interface EJSModule extends EmscriptenModule {
 export declare class EJS_GameManager {
   FS: typeof FS;
   Module: EJSModule;
+  EJS: import("./emulator").EmulatorJS;
 
   functions: {
     saveStateInfo: () => unknown;

--- a/packages/client-web/src/lib/emulatorjs/emulator.d.ts
+++ b/packages/client-web/src/lib/emulatorjs/emulator.d.ts
@@ -23,6 +23,7 @@ export declare class EmulatorJS {
   isFastForward: boolean;
   paused: boolean;
   coreName: Core;
+  fileName: string;
   saveFileExt: string | false;
   functions?: { [key: string]: Array<() => unknown> };
   touch?: boolean;
@@ -86,7 +87,8 @@ export declare class EmulatorJS {
   };
   requiresThreads(core: unknown): unknown;
   requiresWebGL2(core: unknown): unknown;
-  getCore(generic: unknown): unknown;
+  getCore(generic?: boolean): string;
+  getBaseFileName(force?: boolean): string;
   createElement(type: unknown): unknown;
   addEventListener(
     element: unknown,
@@ -113,7 +115,7 @@ export declare class EmulatorJS {
   createStartButton(): void;
   startButtonClicked(e: unknown): void;
   createText(): void;
-  localization(text: unknown, log: unknown): unknown;
+  localization(text: unknown, log?: unknown): string;
   checkCompression(data: unknown, msg: unknown, fileCbFunc: unknown): unknown;
   checkCoreCompatibility(version: unknown): void;
   startGameError(message: unknown): void;
@@ -132,6 +134,7 @@ export declare class EmulatorJS {
   downloadGamePatch(): unknown;
   downloadGameParent(): unknown;
   downloadBios(): unknown;
+  textElem: HTMLElement;
   downloadRom(): unknown;
   downloadFiles(): void;
   initModule(wasmData: unknown, threadData: unknown): void;

--- a/packages/client-web/src/providers/emulator-js/ejs-session.tsx
+++ b/packages/client-web/src/providers/emulator-js/ejs-session.tsx
@@ -58,12 +58,20 @@ export function EJSSessionStateProvider(props: PropsWithChildren) {
 
     emulatorJS.gameManager.saveSaveFiles();
 
-    const fullPath: string = emulatorJS.gameManager?.getSaveFilePath() ?? "";
+    let fullPath: string = emulatorJS.gameManager?.getSaveFilePath() ?? "";
     if (!fullPath) {
       return;
     }
 
     const FS = emulatorJS.gameManager.FS;
+
+    if (!FS.analyzePath(fullPath).exists && fullPath.endsWith(".srm")) {
+      const pureZipPath = fullPath.replace(/\.srm$/, ".pure.zip");
+      if (FS.analyzePath(pureZipPath).exists) {
+        fullPath = pureZipPath;
+      }
+    }
+
     if (!FS.analyzePath(fullPath).exists) {
       console.warn(
         `Save file not found (is this core supported?): ${fullPath}`,

--- a/packages/client-web/src/providers/emulator-js/index.tsx
+++ b/packages/client-web/src/providers/emulator-js/index.tsx
@@ -82,6 +82,18 @@ export function EmulatorJSProvider(props: { children: ReactNode }) {
           disableDatabases: true,
           gameName: gameMetadata?.name ?? getFileStub(game.path),
           gameID: game.id,
+          ...(isDosBoxPure && {
+            externalFiles: {
+              "/system/MT32_CONTROL.ROM": new URL(
+                "./rest/public/system/MT32_CONTROL.ROM",
+                apiUrl,
+              ).toString(),
+              "/system/MT32_PCM.ROM": new URL(
+                "./rest/public/system/MT32_PCM.ROM",
+                apiUrl,
+              ).toString(),
+            },
+          }),
           ready: () => {
             const ejs = window.EJS_emulator;
 

--- a/packages/client-web/src/providers/emulator-js/index.tsx
+++ b/packages/client-web/src/providers/emulator-js/index.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode } from "react";
+import { createContext, useContext, ReactNode, useRef } from "react";
 import { Config, Core } from "@/lib/emulatorjs";
 import { EmulatorJS } from "@/lib/emulatorjs/emulator";
 import { useQuery } from "@tanstack/react-query";
@@ -11,6 +11,9 @@ import { CoreOptionsProvider } from "./core-options";
 import { ControlOptionsProvider } from "./control-options";
 import { GameOptionsProvider } from "./game-options";
 import { EJSSessionStateProvider } from "./ejs-session";
+import { useRetromClient } from "../retrom-client";
+import { create } from "@bufbuild/protobuf";
+import { GetSaveFilesRequestSchema } from "@retrom/codegen/retrom/services/saves/v1/saves-service_pb";
 
 type EmulatorJSContextValue = EmulatorJS;
 
@@ -24,8 +27,11 @@ export function EmulatorJSProvider(props: { children: ReactNode }) {
   const { gameFiles, game, gameMetadata, defaultProfile, emulator } =
     useGameDetail();
   const { children } = props;
+  const retromClient = useRetromClient();
 
   const core = (coreName ?? emulator?.libretroName) as Core | undefined;
+  const isDosBoxPure = core === "dosbox_pure";
+
   const file =
     gameFiles.find((f) => f.id === game.defaultFileId) ??
     gameFiles.find(
@@ -34,6 +40,10 @@ export function EmulatorJSProvider(props: { children: ReactNode }) {
         defaultProfile.supportedExtensions.some((e) => f.path.endsWith(e)),
     ) ??
     gameFiles[0];
+
+  const savesPromiseRef = useRef<ReturnType<
+    typeof retromClient.savesClient.getSaveFiles
+  > | null>(null);
 
   const { data: emulatorJS } = useQuery({
     queryKey: ["emulator-js", apiUrl, file.id],
@@ -49,6 +59,16 @@ export function EmulatorJSProvider(props: { children: ReactNode }) {
         const loaderUrl = new URL("./loader.js", dataUrl);
         const gameUrl = new URL(`./rest/file/${file.id}`, apiUrl).toString();
 
+        if (isDosBoxPure) {
+          savesPromiseRef.current = retromClient.savesClient.getSaveFiles(
+            create(GetSaveFilesRequestSchema, {
+              saveFilesSelectors: [
+                { gameId: game.id, emulatorId: emulator?.id },
+              ],
+            }),
+          );
+        }
+
         const configFinal: Config = {
           player: "#game",
           gameUrl,
@@ -63,28 +83,36 @@ export function EmulatorJSProvider(props: { children: ReactNode }) {
           gameName: gameMetadata?.name ?? getFileStub(game.path),
           gameID: game.id,
           ready: () => {
-            const emulator = window.EJS_emulator;
+            const ejs = window.EJS_emulator;
 
-            if (!emulator) {
+            if (!ejs) {
               return reject(new Error("emulatorJS not initialized"));
             }
 
             console.log("EmulatorJS initialized");
-            console.log(emulator);
+            console.log(ejs);
 
-            emulator.on("exit", () => {
+            ejs.on("exit", () => {
               console.warn("emulatorJS called exit");
             });
+
+            if (isDosBoxPure) {
+              patchDownloadRom(ejs, savesPromiseRef.current);
+            }
           },
           onGameStart: () => {
             console.log("emulatorJS called game-start");
-            const emulator = window.EJS_emulator;
+            const ejs = window.EJS_emulator;
 
-            if (!emulator) {
+            if (!ejs) {
               return reject(new Error("emulatorJS not initialized"));
             }
 
-            resolve(emulator);
+            if (isDosBoxPure) {
+              patchGetSaveFilePath(ejs);
+            }
+
+            resolve(ejs);
           },
           onSaveSave: () => {
             console.warn("emulatorJS called save-save");
@@ -147,4 +175,87 @@ export function useEmulatorJS() {
 
 export function useMaybeEmulatorJS() {
   return useContext(EmulatorJSContext);
+}
+
+/**
+ * Fix 1 + Fix 3: Monkey-patch downloadRom to write the game ZIP as-is
+ * (instead of extracting it) and inject cloud saves before core init.
+ *
+ * DOSBox Pure needs the ZIP directly so it can mount it as a virtual drive
+ * and track filesystem changes into a .pure.zip save archive.
+ */
+function patchDownloadRom(
+  ejs: EmulatorJS,
+  savesPromise: ReturnType<
+    ReturnType<typeof useRetromClient>["savesClient"]["getSaveFiles"]
+  > | null,
+) {
+  ejs.downloadRom = async function (this: EmulatorJS) {
+    this.textElem.innerText = this.localization("Download Game Data");
+
+    const gameUrl = this.config.gameUrl ?? "";
+    const fileId = gameUrl.split("/").pop() ?? "game";
+    const fileName = fileId + ".zip";
+
+    const resp = await fetch(gameUrl);
+    const data = new Uint8Array(await resp.arrayBuffer());
+
+    this.fileName = fileName;
+    this.gameManager!.FS.writeFile(fileName, data);
+
+    if (savesPromise) {
+      try {
+        const saveResponse = await savesPromise;
+        const saveFiles = saveResponse.saveFiles.at(0);
+
+        if (saveFiles) {
+          const FS = this.gameManager!.FS;
+          for (const { stat, content } of saveFiles.files) {
+            if (!stat) continue;
+            const pathFromStat = stat.path;
+            const fullPath = pathFromStat.startsWith("/")
+              ? pathFromStat
+              : "/" + pathFromStat;
+
+            const pathSegments = fullPath.split("/").filter(Boolean);
+            const parentSegments = pathSegments.slice(0, -1);
+            for (let i = 1; i <= parentSegments.length; i++) {
+              const dir = "/" + parentSegments.slice(0, i).join("/");
+              if (!FS.analyzePath(dir).exists) {
+                FS.mkdir(dir);
+              }
+            }
+
+            if (FS.analyzePath(fullPath).exists) {
+              FS.unlink(fullPath);
+            }
+
+            FS.writeFile(fullPath, content);
+          }
+          console.log("[retrom] Cloud saves written to FS before core init");
+        }
+      } catch (e) {
+        console.error("[retrom] Failed to pre-load cloud saves:", e);
+      }
+    }
+  }.bind(ejs);
+}
+
+/**
+ * Fix 2: Monkey-patch getSaveFilePath on the gameManager so it returns
+ * the .pure.zip path instead of .srm for DOSBox Pure.
+ */
+function patchGetSaveFilePath(ejs: EmulatorJS) {
+  const gm = ejs.gameManager;
+  if (!gm) return;
+
+  const original = gm.getSaveFilePath.bind(gm);
+
+  gm.getSaveFilePath = function () {
+    const p = original();
+    if (p && p.endsWith(".srm")) {
+      return p.replace(/\.srm$/, ".pure.zip");
+    }
+    return p;
+  };
 }


### PR DESCRIPTION
**Draft — submitted for discussion and review.** Not ready for merge; feedback welcome.

---

### Summary

This PR makes DOSBox Pure usable with Retrom’s web client: cloud saves work (ZIP passed through, save restore before core start, correct `.pure.zip` path), and optional MT-32 support via ROMs in the data public system dir.

### Commits

**1. `d1f82909` — fix(client-web): DOSBox Pure cloud saves — ZIP-direct load + restore timing**

#### Dosbox pure docs (save data)
https://docs.libretro.com/library/dosbox_pure/
> Extensions: Lists .zip with “see Load games from ZIP”.

_“DOSBox Pure can load games directly from ZIP files without the need to extract them.”_

Store modifications in separate save files:

_“Changes made to a loaded ZIP file will be stored as a separate ZIP file into the libretro saves directory. If a game is loaded directly without using a ZIP file, the saves directory is not used.”_

This lead me to believe we'll want to load the game as a ZIP, prevent extraction, and then we'll get the modified game data written back into a ZIP file, which will be made available for upload.

Since DOSBox Pure expects the game as a single ZIP (mounts it as C:, tracks changes in a `.pure.zip` save). EmulatorJS normally extracts every ZIP before passing content to cores, so DOSBox Pure never saw the ZIP and never created save archives. Restore also failed (e.g. in incognito) because cloud saves were written after the core had already started.

**Note: I also updated the Dosbox Pure emulator to use a save strategy of "Single File" due to this.

**2. `4323fdbb` — feat(client-web): MT-32 support for DOSBox Pure via container system ROMs**

- Set EmulatorJS `externalFiles` for `dosbox_pure` to load `MT32_CONTROL.ROM` and `MT32_PCM.ROM` from `rest/public/system/` (served from the data public dir). 
- Users have a one-time setup: place the two ROMs in `{data}/public/system/` (e.g. `/app/data/public/system/` in Docker).

### Testing

- Game added as ZIP: loads in DOSBox Pure, C: mount and in-game saves work; cloud save upload/download uses `.pure.zip`.
- Save restore in a fresh/incognito session: overlay present before core start, game sees saved state.
- Works across browser platforms too.
- With MT-32 ROMs in `public/system/`, core option “Roland MT-32” works in-game.

### Upstream

The proper long-term fix is likely in EmulatorJS: skip extraction for DOS (and use `.pure.zip` save path). These client patches can be removed once that lands.