### PR TITLE
chore(docker): update node to 24 and replace pnpm vite preview with serve for static assets

### DIFF
--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -91,6 +91,10 @@ COPY --from=web-builder /web /app/web
 COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/start.sh /app/start.sh
 
+# Strip \r after modifying the file on Windows
+RUN sed -i 's/\r//' /entrypoint.sh
+RUN sed -i 's/\r//' /app/start.sh
+
 RUN mkdir -p /app/data/db && \
   mkdir /app/psql && \
   mkdir /app/config

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -9,6 +9,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm i -g corepack@latest
 RUN corepack enable
+RUN npm i -g serve
 RUN apt-get update && apt-get install -y \
   protobuf-compiler \
   ca-certificates \

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim AS common
+FROM node:24-bookworm-slim AS common
 
 FROM common AS project
 COPY . /app/

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -9,7 +9,8 @@ trap 'on_error $LINENO' ERR
 
 # Start the web server
 cd /app/web
-VITE_RETROM_LOCAL_SERVICE_HOST=http://localhost:5101 pnpm vite preview &
+VITE_RETROM_LOCAL_SERVICE_HOST=http://localhost:5101
+npx serve dist -l ${RETROM_WEB_PORT} &
 web_pid=$!
 
 # Start the API server


### PR DESCRIPTION
Updating the base node image to node:24-bookworm-slim.

Also, during startup, using pnpm vite preview was causing an error due to the lack of TTY, move to serving compiled assets from dist directly