### PR TITLE
fix: hide unconfigured Steam platform and show standalone progress

### DIFF
--- a/packages/client-web/src/components/modals/config/client/connection-config.tsx
+++ b/packages/client-web/src/components/modals/config/client/connection-config.tsx
@@ -41,6 +41,12 @@ export function ConnectionConfig() {
     useDisableStandaloneMode();
 
   const pending = enableStatus === "pending" || disableStatus === "pending";
+  const pendingStandaloneAction =
+    enableStatus === "pending"
+      ? "enable"
+      : disableStatus === "pending"
+        ? "disable"
+        : undefined;
 
   const toggleStandaloneMode = useCallback(async () => {
     if (serverConfig?.standalone) {
@@ -122,6 +128,7 @@ export function ConnectionConfig() {
         <div className="flex items-top gap-2">
           <Checkbox
             id="install-in-standalone"
+            disabled={pending}
             checked={!!serverConfig?.installGamesInStandalone}
             onCheckedChange={(value) => toggleInstallInStandalone(!!value)}
           />
@@ -140,6 +147,14 @@ export function ConnectionConfig() {
             </p>
           </div>
         </div>
+
+        {pendingStandaloneAction ? (
+          <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            {pendingStandaloneAction === "enable"
+              ? "Preparing standalone mode. First-time setup can take a minute while Retrom starts the local server and prepares EmulatorJS."
+              : "Disabling standalone mode. Please wait while Retrom disconnects from the local server."}
+          </div>
+        ) : null}
 
         <Separator />
 

--- a/packages/grpc-service/src/lib.rs
+++ b/packages/grpc-service/src/lib.rs
@@ -131,8 +131,10 @@ pub fn grpc_service(db_url: &str, config_manager: Arc<ServerConfigManager>) -> R
     ));
 
     let game_service = GameServiceServer::new(GameServiceHandlers::new(shared_pool.clone()));
-    let platform_service =
-        PlatformServiceServer::new(PlatformServiceHandlers::new(shared_pool.clone()));
+    let platform_service = PlatformServiceServer::new(PlatformServiceHandlers::new(
+        shared_pool.clone(),
+        config_manager.clone(),
+    ));
 
     let client_service =
         ClientServiceServer::new(clients::ClientServiceHandlers::new(shared_pool.clone()));

--- a/packages/grpc-service/src/platforms.rs
+++ b/packages/grpc-service/src/platforms.rs
@@ -7,18 +7,25 @@ use retrom_codegen::retrom::{
     PlatformMetadata, UpdatePlatformsRequest, UpdatePlatformsResponse,
 };
 use retrom_db::{schema, Pool};
+use retrom_service_common::config::ServerConfigManager;
 use retrom_service_common::media_cache::cacheable_media::CacheableMetadata;
 use std::{path::PathBuf, sync::Arc};
 use tonic::{Code, Request, Response, Status};
 
+const STEAM_PLATFORM_PATH: &str = "__RETROM_RESERVED__/Steam";
+
 #[derive(Clone)]
 pub struct PlatformServiceHandlers {
     pub db_pool: Arc<Pool>,
+    pub config_manager: Arc<ServerConfigManager>,
 }
 
 impl PlatformServiceHandlers {
-    pub fn new(db_pool: Arc<Pool>) -> Self {
-        Self { db_pool }
+    pub fn new(db_pool: Arc<Pool>, config_manager: Arc<ServerConfigManager>) -> Self {
+        Self {
+            db_pool,
+            config_manager,
+        }
     }
 }
 
@@ -50,6 +57,19 @@ impl PlatformService for PlatformServiceHandlers {
             query = query.filter(schema::platforms::is_deleted.eq(false));
         }
 
+        let steam_configured = self
+            .config_manager
+            .get_config()
+            .await
+            .steam
+            .is_some_and(|steam| {
+                !steam.api_key.trim().is_empty() && !steam.user_id.trim().is_empty()
+            });
+
+        if !steam_configured {
+            query = query.filter(schema::platforms::path.ne(STEAM_PLATFORM_PATH));
+        }
+
         let platforms: Vec<retrom::Platform> = match query.load(&mut conn).await {
             Ok(rows) => rows,
             Err(why) => return Err(Status::new(Code::Internal, why.to_string())),
@@ -57,20 +77,21 @@ impl PlatformService for PlatformServiceHandlers {
 
         let metadata = match with_metadata {
             true => {
-                let mut query = schema::platform_metadata::table
-                    .into_boxed()
-                    .select(retrom::PlatformMetadata::as_select());
+                let platform_ids: Vec<_> = platforms.iter().map(|platform| platform.id).collect();
 
-                if !ids.is_empty() {
-                    query = query.filter(schema::platform_metadata::platform_id.eq_any(ids));
+                if platform_ids.is_empty() {
+                    vec![]
+                } else {
+                    let query = schema::platform_metadata::table
+                        .into_boxed()
+                        .filter(schema::platform_metadata::platform_id.eq_any(platform_ids))
+                        .select(retrom::PlatformMetadata::as_select());
+
+                    match query.load(&mut conn).await {
+                        Ok(rows) => rows,
+                        Err(why) => return Err(Status::new(Code::Internal, why.to_string())),
+                    }
                 }
-
-                let metadata: Vec<retrom::PlatformMetadata> = match query.load(&mut conn).await {
-                    Ok(rows) => rows,
-                    Err(why) => return Err(Status::new(Code::Internal, why.to_string())),
-                };
-
-                metadata
             }
             false => vec![],
         };


### PR DESCRIPTION
## Summary
- hide the reserved Steam platform until Steam credentials are actually configured
- scope platform metadata lookups to the platforms returned by the query
- show a clear progress message while standalone mode is enabling or disabling, and lock the standalone install toggle during that transition

## Why
- issue #438 reports that the Steam platform is rendered even when Steam is not configured
- issue #334 asks for visible feedback during slower standalone mode transitions

## Validation
- formatted the updated client file with Prettier
- attempted a TypeScript check for the web client, but this workspace currently falls over on broad module-resolution errors in the local environment after a partial pnpm install
- could not run Cargo-based checks because a Rust toolchain is not available in this environment

Closes #438
Closes #334