### PR TITLE
Make Nix flake packages composable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,11 +23,16 @@
       flake-utils,
       ...
     }:
+    let
+      mkPackages = pkgs: import ./nix/packages.nix { inherit pkgs; };
+    in
     {
+      overlays.default = final: _prev: mkPackages final;
+
       nixosModules.retrom =
         { lib, pkgs, ... }:
         let
-          retromPackages = self.packages.${pkgs.stdenv.hostPlatform.system};
+          retromPackages = mkPackages pkgs;
         in
         {
           imports = [
@@ -40,7 +45,7 @@
       homeModules.retrom =
         { lib, pkgs, ... }:
         let
-          retromPackages = self.packages.${pkgs.stdenv.hostPlatform.system};
+          retromPackages = mkPackages pkgs;
         in
         {
           imports = [
@@ -55,11 +60,7 @@
         pkgs = import nixpkgs { inherit system; };
       in
       {
-        packages = rec {
-          retrom-unwrapped = pkgs.callPackage ./nix/pkgs/retrom-unwrapped/package.nix { };
-          retrom = pkgs.callPackage ./nix/pkgs/retrom/package.nix { inherit retrom-unwrapped; };
-          retrom-service = pkgs.callPackage ./nix/pkgs/retrom-service/package.nix { };
-        };
+        packages = mkPackages pkgs;
       }
     );
 }

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,70 @@
+# Nix
+
+Retrom exposes flake packages, an overlay, and NixOS/Home Manager modules.
+
+## Packages
+
+```sh
+nix build github:JMBeresford/retrom#retrom
+nix build github:JMBeresford/retrom#retrom-service
+```
+
+## Overlay
+
+```nix
+{
+  inputs.retrom.url = "github:JMBeresford/retrom";
+
+  outputs =
+    {
+      nixpkgs,
+      retrom,
+      ...
+    }:
+    {
+      nixosConfigurations.example = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ({ pkgs, ... }: {
+            nixpkgs.overlays = [ retrom.overlays.default ];
+            environment.systemPackages = [ pkgs.retrom ];
+          })
+        ];
+      };
+    };
+}
+```
+
+## Modules
+
+The NixOS and Home Manager modules build their default packages with the
+caller's `pkgs`. Override `programs.retrom.package` or `services.retrom.package`
+to use a custom package.
+
+```nix
+{
+  inputs.retrom.url = "github:JMBeresford/retrom";
+
+  outputs =
+    {
+      nixpkgs,
+      retrom,
+      ...
+    }:
+    {
+      nixosConfigurations.example = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          retrom.nixosModules.retrom
+          {
+            programs.retrom.enable = true;
+            services.retrom.enable = true;
+          }
+        ];
+      };
+    };
+}
+```
+
+The overlay and modules are tested against Retrom's locked Nixpkgs; other
+Nixpkgs revisions may need package fixes.

--- a/nix/README.md
+++ b/nix/README.md
@@ -41,6 +41,16 @@ The NixOS and Home Manager modules build their default packages with the
 caller's `pkgs`. Override `programs.retrom.package` or `services.retrom.package`
 to use a custom package.
 
+By default the service module leaves `RETROM_CONFIG` unset, so the server
+creates and updates configuration in its normal writable application config
+directory. Setting `services.retrom.settings`, `services.retrom.dbUrl`,
+`services.retrom.enableDatabase`, or a non-default `services.retrom.port` seeds
+a writable service configuration before the first start. Existing configuration
+files are left in place so Retrom can update its own server configuration at
+runtime. Set `services.retrom.configFile` to point the service at another
+explicit configuration file, including an immutable generated file when fully
+declarative configuration is desired.
+
 ```nix
 {
   inputs.retrom.url = "github:JMBeresford/retrom";

--- a/nix/nixos/service.nix
+++ b/nix/nixos/service.nix
@@ -6,20 +6,27 @@
 }:
 let
   cfg = config.services.retrom;
-  pgPort = config.services.postgresql.settings.port;
-  settings = cfg.settings // {
-    connection = {
-      inherit (cfg) port;
-      dbUrl = if isNull cfg.dbUrl then
-        "postgres:///retrom?host=/var/run/postgresql"
-      else
-        cfg.dbUrl;
-    };
-  };
-  configFile = if isNull cfg.configFile then
-    pkgs.writeText "retrom-service-config.json" (builtins.toJSON settings)
-  else
-    cfg.configFile;
+  defaultPort = 5101;
+  dbUrl =
+    if !isNull cfg.dbUrl then
+      cfg.dbUrl
+    else if cfg.enableDatabase then
+      "postgres:///retrom?host=/var/run/postgresql"
+    else
+      null;
+  connection =
+    lib.optionalAttrs (cfg.port != defaultPort) { inherit (cfg) port; }
+    // lib.optionalAttrs (!isNull dbUrl) { inherit dbUrl; };
+  settings = cfg.settings // lib.optionalAttrs (connection != { }) { inherit connection; };
+  initialConfigFile = pkgs.writeText "retrom-service-config.json" (builtins.toJSON settings);
+  configFilePath =
+    if !isNull cfg.configFile then
+      cfg.configFile
+    else if settings != { } then
+      "${cfg.dataDir}/.config/retrom/server/config.json"
+    else
+      null;
+  seedConfig = isNull cfg.configFile && settings != { };
 in {
   options.services.retrom = {
     enable = lib.mkEnableOption "Enable Retrom service.";
@@ -49,19 +56,29 @@ in {
     };
     port = lib.mkOption {
       type = lib.types.int;
-      default = 5101;
+      default = defaultPort;
       description = "Port to run the service on. If configFile is set this will only have effect with the openFirewall option.";
     };
     openFirewall = lib.mkEnableOption "Open firewall for TCP port.";
     settings = lib.mkOption {
       type = lib.types.anything;
       default = { };
-      description = "Settings for retrom service. If configFile is set these will be ignored.";
+      description = ''
+        Initial settings for the Retrom service. If this is set, the module
+        seeds a writable configuration file before the first service start.
+        Existing configuration files are left in place so Retrom can update its
+        own server configuration at runtime.
+      '';
     };
     configFile = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
-      description = "Path to the configuration file. If this is set settings will be replaced by it.";
+      description = ''
+        Path to the configuration file. If unset and no initial settings are
+        needed, RETROM_CONFIG is left unset and Retrom uses its default writable
+        configuration path. This can point at an immutable generated file when
+        fully declarative configuration is desired.
+      '';
     };
   };
 
@@ -99,16 +116,26 @@ in {
 
       wantedBy = [ "multi-user.target" ];
 
+      preStart = lib.mkIf seedConfig ''
+        config_file=${lib.escapeShellArg configFilePath}
+        mkdir -p "$(dirname "$config_file")"
+
+        if [ ! -e "$config_file" ]; then
+          install -m 0640 ${initialConfigFile} "$config_file"
+        fi
+      '';
+
       serviceConfig = {
         ExecStart = "${lib.getExe cfg.package}";
         Restart = "on-failure";
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.dataDir;
-        Environment = [
-          "RETROM_DATA_DIR=${cfg.dataDir}"
-          "RETROM_CONFIG=${configFile}"
-        ];
+        Environment =
+          [
+            "RETROM_DATA_DIR=${cfg.dataDir}"
+          ]
+          ++ lib.optional (!isNull configFilePath) "RETROM_CONFIG=${configFilePath}";
       };
     };
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,9 @@
+{ pkgs }:
+
+rec {
+  retrom-unwrapped = pkgs.callPackage ./pkgs/retrom-unwrapped/package.nix { };
+  retrom = pkgs.callPackage ./pkgs/retrom/package.nix {
+    inherit retrom-unwrapped;
+  };
+  retrom-service = pkgs.callPackage ./pkgs/retrom-service/package.nix { };
+}

--- a/nix/pkgs/retrom-service/package.nix
+++ b/nix/pkgs/retrom-service/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 3;
-    hash = "sha256-MmWCpe7NzzT8W/Ic9y1VzGAp4rk0vxoOxbz5sRRlQs0=";
+    hash = "sha256-b4OG+4i+ssaaJFj0SWyzI+dHWLk5XQCiq1TVMhIo/10=";
   };
 
   cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";

--- a/nix/pkgs/retrom-unwrapped/package.nix
+++ b/nix/pkgs/retrom-unwrapped/package.nix
@@ -36,11 +36,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 3;
-    hash = "sha256-MmWCpe7NzzT8W/Ic9y1VzGAp4rk0vxoOxbz5sRRlQs0=";
+    hash = "sha256-b4OG+4i+ssaaJFj0SWyzI+dHWLk5XQCiq1TVMhIo/10=";
   };
 
   cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";
-  
+
   cargoLock.outputHashes = {
     "ludusavi-0.30.0" = "sha256-tDGfnX3fDDvrLvSnWvurIBwgDTWCjmbIJXDxgxQV5Og=";
     "webdav-meta-0.1.0" = "sha256-1XWBxlkdftg/Et7TexNmhKDZXl7ro+agMXodCRMV+e8=";


### PR DESCRIPTION
## Summary

This makes the Nix flake easier to compose from downstream NixOS and Home Manager configurations.

- add a shared `nix/packages.nix` package set
- expose `overlays.default`
- make NixOS/Home Manager module defaults build Retrom packages with the caller's `pkgs`
- update the stale `fetchPnpmDeps` hash for the client and service packages
- keep the NixOS service's live server config writable by default
- document package, overlay, module, and service config behavior

The standalone flake packages still build through Retrom's locked flake inputs, while module consumers can now compose Retrom through their own package set.

The NixOS service can update its own server configuration at runtime, so the module now leaves `RETROM_CONFIG` unset by default. When Nix-provided connection settings are needed, such as `services.retrom.enableDatabase`, the module seeds a writable config file before the first service start. Users who want fully declarative config can still point `services.retrom.configFile` at an immutable generated file.

The split here follows the usual Nix flake convention: `packages.*` are useful as reproducible upstream build artifacts and can use the flake's locked inputs, while overlays and modules are composition surfaces for downstream NixOS/Home Manager users and should normally build through the caller's `pkgs`. That lets users choose whether they want Retrom's pinned package graph or integration with their own Nixpkgs revision; the latter may need occasional package fixes when Nixpkgs helper behavior changes.

## Compatibility

The overlay and modules are tested against Retrom's locked Nixpkgs; other Nixpkgs revisions may need package fixes.

## Verification

```sh
nix eval --raw .#retrom-unwrapped.pnpmDeps.outputHash
nix build .#retrom-unwrapped.pnpmDeps --no-link
nix build .#retrom-service.pnpmDeps --no-link
nix flake check --no-build
```

Also evaluated the NixOS service module for default, `enableDatabase`, and explicit `configFile` configurations.
