### PR TITLE
Nix/update pnpm fetcher version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {

--- a/nix/pkgs/retrom-service/package.nix
+++ b/nix/pkgs/retrom-service/package.nix
@@ -11,29 +11,39 @@
   protobuf_29,
   openssl,
   makeWrapper,
+
+  withEmbeddedDb ? false,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "retrom-service";
-  inherit ((builtins.fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+  inherit ((fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+
+  __structuredAttrs = true;
 
   src = lib.cleanSourceWith {
     src = ../../../.;
-    filter = path: _: !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
-      /nix
-      /flake.nix
-      /flake.lock
+    filter =
+      path: _:
+      !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
+        /nix
+        /flake.nix
+        /flake.lock
 
-      /.github
-      /.gitignore
-    ]);
+        /.github
+        /.gitignore
+      ]);
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 3;
-    hash = "sha256-MmWCpe7NzzT8W/Ic9y1VzGAp4rk0vxoOxbz5sRRlQs0=";
+    hash = "sha256-b4OG+4i+ssaaJFj0SWyzI+dHWLk5XQCiq1TVMhIo/10=";
   };
+
+  buildAndTestSubdir = "packages/service";
+
+  cargoBuildFeatures = lib.optional withEmbeddedDb "embedded_db";
 
   cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";
 
@@ -41,8 +51,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "ludusavi-0.30.0" = "sha256-tDGfnX3fDDvrLvSnWvurIBwgDTWCjmbIJXDxgxQV5Og=";
     "webdav-meta-0.1.0" = "sha256-1XWBxlkdftg/Et7TexNmhKDZXl7ro+agMXodCRMV+e8=";
   };
-
-  buildAndTestSubdir = "packages/service";
 
   nativeBuildInputs = [
     pkg-config
@@ -59,50 +67,48 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ];
 
-  buildPhase = ''
+  preBuild = ''
     export CI=true
     export NX_NO_CLOUD=true
     export NX_DAEMON=false
 
     export VITE_BASE_URL=/web
-    export VITE_UPTRACE_DSN=https://KgFBXOxX2RFeJurwr7R-4w@api.uptrace.dev?grpc=4317
 
     # See https://github.com/nrwl/nx/issues/22445
     faketty pnpm nx build retrom-client-web
 
-    runHook cargoBuildHook
+    # Work around for https://github.com/pnpm/pnpm/issues/5315
+    mkdir -p web
+
+    cp -r packages/client-web/dist web
+
+    cp pnpm-workspace.yaml web
+    cp pnpm-lock.yaml web
+    cp package.json web
+    cp README.md web
+    cp packages/client-web/vite.config.ts web
+
+    pushd web
+    pnpm install --prod --offline --frozen-lockfile
+
+    rm -f pnpm-workspace.yaml pnpm-lock.yaml
+    popd
   '';
 
   postInstall = ''
-    dst=$out/share/retrom
-    mkdir -p $dst
-
-    # Work around for https://github.com/pnpm/pnpm/issues/5315
-    cp -r packages/client-web/dist $dst
-
-    cp pnpm-workspace.yaml $dst
-    cp pnpm-lock.yaml $dst
-    cp package.json $dst
-
-    cp README.md $dst
-    cp packages/client-web/vite.config.ts $dst
-
-    cd $dst
-    pnpm install --prod --offline --frozen-lockfile
-
-    rm pnpm-workspace.yaml
-    rm pnpm-lock.yaml
+    mkdir -p $out/share
+    cp -r web $out/share/retrom
   '';
 
   postFixup = ''
     wrapProgram $out/bin/retrom-service --set RETROM_WEB_DIR $out/share/retrom
   '';
 
-  meta = with lib; {
-    description = "A centralized game library/collection management service with a focus on emulation";
+  meta = {
+    description = "Server component of the Retrom game library management service";
     homepage = "https://github.com/JMBeresford/retrom";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
     mainProgram = "retrom-service";
   };
 })

--- a/nix/pkgs/retrom-service/package.nix
+++ b/nix/pkgs/retrom-service/package.nix
@@ -37,8 +37,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 3;
-    hash = "sha256-b4OG+4i+ssaaJFj0SWyzI+dHWLk5XQCiq1TVMhIo/10=";
+    fetcherVersion = 4;
+    hash = "sha256-vGNlVEYBGYwaUMfsz6Cat4ZWPOfTHjbjuehsFi3zDoE=";
   };
 
   buildAndTestSubdir = "packages/service";

--- a/nix/pkgs/retrom-service/package.nix
+++ b/nix/pkgs/retrom-service/package.nix
@@ -37,8 +37,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
     fetcherVersion = 4;
-    hash = "sha256-vGNlVEYBGYwaUMfsz6Cat4ZWPOfTHjbjuehsFi3zDoE=";
+    hash = "sha256-5FkJc/rtptg4ZWlf1NU/57Ga8cLbW1LVc4MLxs+iyrA=";
   };
 
   buildAndTestSubdir = "packages/service";
@@ -73,6 +74,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     export NX_DAEMON=false
 
     export VITE_BASE_URL=/web
+    export VITE_UPTRACE_DSN=https://KgFBXOxX2RFeJurwr7R-4w@api.uptrace.dev?grpc=4317
 
     # See https://github.com/nrwl/nx/issues/22445
     faketty pnpm nx build retrom-client-web

--- a/nix/pkgs/retrom-unwrapped/package.nix
+++ b/nix/pkgs/retrom-unwrapped/package.nix
@@ -39,8 +39,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
     fetcherVersion = 4;
-    hash = "sha256-vGNlVEYBGYwaUMfsz6Cat4ZWPOfTHjbjuehsFi3zDoE=";
+    hash = "sha256-5FkJc/rtptg4ZWlf1NU/57Ga8cLbW1LVc4MLxs+iyrA=";
   };
 
   cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";

--- a/nix/pkgs/retrom-unwrapped/package.nix
+++ b/nix/pkgs/retrom-unwrapped/package.nix
@@ -39,8 +39,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 3;
-    hash = "sha256-b4OG+4i+ssaaJFj0SWyzI+dHWLk5XQCiq1TVMhIo/10=";
+    fetcherVersion = 4;
+    hash = "sha256-vGNlVEYBGYwaUMfsz6Cat4ZWPOfTHjbjuehsFi3zDoE=";
   };
 
   cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";

--- a/nix/pkgs/retrom-unwrapped/package.nix
+++ b/nix/pkgs/retrom-unwrapped/package.nix
@@ -19,28 +19,32 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "retrom";
-  inherit ((builtins.fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+  inherit ((fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+
+  __structuredAttrs = true;
 
   src = lib.cleanSourceWith {
     src = ../../../.;
-    filter = path: _: !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
-      /nix
-      /flake.nix
-      /flake.lock
+    filter =
+      path: _:
+      !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
+        /nix
+        /flake.nix
+        /flake.lock
 
-      /.github
-      /.gitignore
-    ]);
+        /.github
+        /.gitignore
+      ]);
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 3;
-    hash = "sha256-MmWCpe7NzzT8W/Ic9y1VzGAp4rk0vxoOxbz5sRRlQs0=";
+    hash = "sha256-b4OG+4i+ssaaJFj0SWyzI+dHWLk5XQCiq1TVMhIo/10=";
   };
 
   cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";
-  
+
   cargoLock.outputHashes = {
     "ludusavi-0.30.0" = "sha256-tDGfnX3fDDvrLvSnWvurIBwgDTWCjmbIJXDxgxQV5Og=";
     "webdav-meta-0.1.0" = "sha256-1XWBxlkdftg/Et7TexNmhKDZXl7ro+agMXodCRMV+e8=";
@@ -68,22 +72,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gst_all_1.gst-plugins-good
   ];
 
-  buildPhase = ''
+  preBuild = ''
     export CI=true
     export NX_NO_CLOUD=true
     export NX_DAEMON=false
 
     # See https://github.com/nrwl/nx/issues/22445
     faketty pnpm nx build:desktop retrom-client-web
-
-    runHook tauriBuildHook
   '';
 
-  meta = with lib; {
-    description = "A centralized game library/collection management service with a focus on emulation";
+  meta = {
+    description = "Desktop client for the Retrom game library management service";
     homepage = "https://github.com/JMBeresford/retrom";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
     mainProgram = "Retrom";
   };
 })

--- a/packages/nix-release/src/template.ts
+++ b/packages/nix-release/src/template.ts
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 3;
+    fetcherVersion = 4;
     hash = "${pnpmDepsHash}";
   };
 
@@ -166,7 +166,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 3;
+    fetcherVersion = 4;
     hash = "${pnpmDepsHash}";
   };
 

--- a/packages/nix-release/src/template.ts
+++ b/packages/nix-release/src/template.ts
@@ -41,6 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
     fetcherVersion = 4;
     hash = "${pnpmDepsHash}";
   };
@@ -77,6 +78,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     export NX_DAEMON=false
 
     export VITE_BASE_URL=/web
+    export VITE_UPTRACE_DSN=https://KgFBXOxX2RFeJurwr7R-4w@api.uptrace.dev?grpc=4317
 
     # See https://github.com/nrwl/nx/issues/22445
     faketty pnpm nx build retrom-client-web
@@ -166,6 +168,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
     fetcherVersion = 4;
     hash = "${pnpmDepsHash}";
   };

--- a/packages/nix-release/src/template.ts
+++ b/packages/nix-release/src/template.ts
@@ -15,22 +15,28 @@ export function renderServicePackageTemplate(opts: { pnpmDepsHash: string }) {
   protobuf_29,
   openssl,
   makeWrapper,
+
+  withEmbeddedDb ? false,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "retrom-service";
-  inherit ((builtins.fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+  inherit ((fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+
+  __structuredAttrs = true;
 
   src = lib.cleanSourceWith {
     src = ../../../.;
-    filter = path: _: !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
-      /nix
-      /flake.nix
-      /flake.lock
+    filter =
+      path: _:
+      !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
+        /nix
+        /flake.nix
+        /flake.lock
 
-      /.github
-      /.gitignore
-    ]);
+        /.github
+        /.gitignore
+      ]);
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -39,14 +45,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "${pnpmDepsHash}";
   };
 
+  buildAndTestSubdir = "packages/service";
+
+  cargoBuildFeatures = lib.optional withEmbeddedDb "embedded_db";
+
   cargoLock.lockFile = "\${finalAttrs.src}/Cargo.lock";
 
   cargoLock.outputHashes = {
     "ludusavi-0.30.0" = "sha256-tDGfnX3fDDvrLvSnWvurIBwgDTWCjmbIJXDxgxQV5Og=";
     "webdav-meta-0.1.0" = "sha256-1XWBxlkdftg/Et7TexNmhKDZXl7ro+agMXodCRMV+e8=";
   };
-
-  buildAndTestSubdir = "packages/service";
 
   nativeBuildInputs = [
     pkg-config
@@ -63,50 +71,48 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ];
 
-  buildPhase = ''
+  preBuild = ''
     export CI=true
     export NX_NO_CLOUD=true
     export NX_DAEMON=false
 
     export VITE_BASE_URL=/web
-    export VITE_UPTRACE_DSN=https://KgFBXOxX2RFeJurwr7R-4w@api.uptrace.dev?grpc=4317
 
     # See https://github.com/nrwl/nx/issues/22445
     faketty pnpm nx build retrom-client-web
 
-    runHook cargoBuildHook
+    # Work around for https://github.com/pnpm/pnpm/issues/5315
+    mkdir -p web
+
+    cp -r packages/client-web/dist web
+
+    cp pnpm-workspace.yaml web
+    cp pnpm-lock.yaml web
+    cp package.json web
+    cp README.md web
+    cp packages/client-web/vite.config.ts web
+
+    pushd web
+    pnpm install --prod --offline --frozen-lockfile
+
+    rm -f pnpm-workspace.yaml pnpm-lock.yaml
+    popd
   '';
 
   postInstall = ''
-    dst=$out/share/retrom
-    mkdir -p $dst
-
-    # Work around for https://github.com/pnpm/pnpm/issues/5315
-    cp -r packages/client-web/dist $dst
-
-    cp pnpm-workspace.yaml $dst
-    cp pnpm-lock.yaml $dst
-    cp package.json $dst
-
-    cp README.md $dst
-    cp packages/client-web/vite.config.ts $dst
-
-    cd $dst
-    pnpm install --prod --offline --frozen-lockfile
-
-    rm pnpm-workspace.yaml
-    rm pnpm-lock.yaml
+    mkdir -p $out/share
+    cp -r web $out/share/retrom
   '';
 
   postFixup = ''
     wrapProgram $out/bin/retrom-service --set RETROM_WEB_DIR $out/share/retrom
   '';
 
-  meta = with lib; {
-    description = "A centralized game library/collection management service with a focus on emulation";
+  meta = {
+    description = "Server component of the Retrom game library management service";
     homepage = "https://github.com/JMBeresford/retrom";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
     mainProgram = "retrom-service";
   };
 })
@@ -140,18 +146,22 @@ export function renderClientPackageTemplate(opts: { pnpmDepsHash: string }) {
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "retrom";
-  inherit ((builtins.fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+  inherit ((fromTOML (builtins.readFile ../../../Cargo.toml)).workspace.package) version;
+
+  __structuredAttrs = true;
 
   src = lib.cleanSourceWith {
     src = ../../../.;
-    filter = path: _: !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
-      /nix
-      /flake.nix
-      /flake.lock
+    filter =
+      path: _:
+      !(builtins.any (prefix: lib.path.hasPrefix (../../../. + prefix) (/. + path)) [
+        /nix
+        /flake.nix
+        /flake.lock
 
-      /.github
-      /.gitignore
-    ]);
+        /.github
+        /.gitignore
+      ]);
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -161,7 +171,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoLock.lockFile = "\${finalAttrs.src}/Cargo.lock";
-  
+
   cargoLock.outputHashes = {
     "ludusavi-0.30.0" = "sha256-tDGfnX3fDDvrLvSnWvurIBwgDTWCjmbIJXDxgxQV5Og=";
     "webdav-meta-0.1.0" = "sha256-1XWBxlkdftg/Et7TexNmhKDZXl7ro+agMXodCRMV+e8=";
@@ -189,22 +199,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gst_all_1.gst-plugins-good
   ];
 
-  buildPhase = ''
+  preBuild = ''
     export CI=true
     export NX_NO_CLOUD=true
     export NX_DAEMON=false
 
     # See https://github.com/nrwl/nx/issues/22445
     faketty pnpm nx build:desktop retrom-client-web
-
-    runHook tauriBuildHook
   '';
 
-  meta = with lib; {
-    description = "A centralized game library/collection management service with a focus on emulation";
+  meta = {
+    description = "Desktop client for the Retrom game library management service";
     homepage = "https://github.com/JMBeresford/retrom";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
     mainProgram = "Retrom";
   };
 })


### PR DESCRIPTION
Fixes #561

Updated the pnpm dependency fetcher from version 3 to 4. This resolves breakage that would have occurred when updating the nixpkgs version due to deprecation of the version 3 fetcher.

There are also small miscellaneous adjustments and improvements, including updating the nix `flake.lock`.

Changes were made to both templates and nix packages and I have verified successful builds for both packages on my system. 